### PR TITLE
perf: lazy-load export libraries in analytics & feat: implement IndexerService upsert

### DIFF
--- a/Backend/src/gists/entities/gist.entity.ts
+++ b/Backend/src/gists/entities/gist.entity.ts
@@ -15,6 +15,7 @@ export class Gist {
   @Column({ type: 'varchar', length: 100, nullable: true })
   content_hash: string | null;
 
+  @Index({ unique: true })
   @Column({ type: 'varchar', length: 80, nullable: true })
   stellar_gist_id: string | null;
 

--- a/Backend/src/gists/gist.repository.ts
+++ b/Backend/src/gists/gist.repository.ts
@@ -22,6 +22,15 @@ export interface CreateGistData {
   tx_hash?: string;
 }
 
+export interface UpsertEventData {
+  stellar_gist_id: string;
+  location_cell: string;
+  content_hash: string;
+  lat: number;
+  lon: number;
+  created_at: Date;
+}
+
 @Injectable()
 export class GistRepository {
   constructor(@InjectDataSource() private readonly dataSource: DataSource) {}
@@ -120,5 +129,62 @@ export class GistRepository {
       [id],
     );
     return rows[0] ?? null;
+  }
+
+  async findByStellarGistId(stellarGistId: string): Promise<Gist | null> {
+    const rows = await this.dataSource.query<Gist[]>(
+      `
+      SELECT
+        id, content, location_cell, content_hash,
+        stellar_gist_id, tx_hash, created_at,
+        ST_X(location::geometry) AS lon,
+        ST_Y(location::geometry) AS lat
+      FROM gists
+      WHERE stellar_gist_id = $1
+      LIMIT 1
+      `,
+      [stellarGistId],
+    );
+    return rows[0] ?? null;
+  }
+
+  async upsertFromEvent(data: UpsertEventData): Promise<Gist> {
+    const { stellar_gist_id, location_cell, content_hash, lat, lon, created_at } = data;
+
+    const result = await this.dataSource.query<Gist[]>(
+      `
+      INSERT INTO gists (
+        content, location, location_cell,
+        content_hash, stellar_gist_id, created_at
+      )
+      VALUES (
+        $1,
+        ST_SetSRID(ST_MakePoint($2, $3), 4326)::geography,
+        $4, $5, $6, $7
+      )
+      ON CONFLICT (stellar_gist_id)
+      DO UPDATE SET
+        location_cell = EXCLUDED.location_cell,
+        content_hash  = EXCLUDED.content_hash,
+        location      = EXCLUDED.location,
+        created_at    = EXCLUDED.created_at
+      RETURNING
+        id, content, location_cell, content_hash,
+        stellar_gist_id, tx_hash, created_at,
+        ST_X(location::geometry) AS lon,
+        ST_Y(location::geometry) AS lat
+      `,
+      [
+        `[Indexed from on-chain event]`,
+        lon,
+        lat,
+        location_cell,
+        content_hash,
+        stellar_gist_id,
+        created_at,
+      ],
+    );
+
+    return result[0];
   }
 }

--- a/Backend/src/indexer/indexer.module.ts
+++ b/Backend/src/indexer/indexer.module.ts
@@ -1,9 +1,13 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { IndexerService } from './indexer.service';
 import { SorobanModule } from '../soroban/soroban.module';
+import { Gist } from '../gists/entities/gist.entity';
+import { GistRepository } from '../gists/gist.repository';
+import { GeoModule } from '../geo/geo.module';
 
 @Module({
-  imports: [SorobanModule],
-  providers: [IndexerService],
+  imports: [TypeOrmModule.forFeature([Gist]), SorobanModule, GeoModule],
+  providers: [IndexerService, GistRepository],
 })
 export class IndexerModule {}

--- a/Backend/src/indexer/indexer.service.ts
+++ b/Backend/src/indexer/indexer.service.ts
@@ -1,23 +1,64 @@
-import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
 import { SorobanService } from '../soroban/soroban.service';
+import { GistRepository } from '../gists/gist.repository';
+import { GeoService } from '../geo/geo.service';
 
 @Injectable()
-export class IndexerService implements OnModuleInit {
+export class IndexerService implements OnModuleInit, OnModuleDestroy {
   private readonly logger = new Logger(IndexerService.name);
   private lastProcessedLedger = 0;
   private pollInterval: NodeJS.Timeout | null = null;
+  private readonly cursorFilePath = join(process.cwd(), '.indexer-cursor');
 
-  constructor(private readonly soroban: SorobanService) {}
+  constructor(
+    private readonly soroban: SorobanService,
+    private readonly gistRepository: GistRepository,
+    private readonly geoService: GeoService,
+  ) {}
 
   onModuleInit() {
-    this.logger.log('Indexer starting — polling Soroban for GistRegistry events');
+    this.loadCursor();
+    this.logger.log(
+      `Indexer starting — polling Soroban for GistRegistry events from ledger ${this.lastProcessedLedger}`,
+    );
     this.startPolling();
+  }
+
+  onModuleDestroy() {
+    if (this.pollInterval) clearInterval(this.pollInterval);
   }
 
   private startPolling(intervalMs = 6_000) {
     this.pollInterval = setInterval(() => {
       void this.poll();
     }, intervalMs);
+  }
+
+  private loadCursor(): void {
+    try {
+      if (existsSync(this.cursorFilePath)) {
+        const data = readFileSync(this.cursorFilePath, 'utf-8').trim();
+        const parsed = parseInt(data, 10);
+        if (!isNaN(parsed) && parsed > 0) {
+          this.lastProcessedLedger = parsed;
+          this.logger.log(`Resumed from persisted cursor: ledger ${this.lastProcessedLedger}`);
+          return;
+        }
+      }
+    } catch (err) {
+      this.logger.warn('Could not load cursor file, starting from 0', err);
+    }
+    this.lastProcessedLedger = 0;
+  }
+
+  private saveCursor(ledger: number): void {
+    try {
+      writeFileSync(this.cursorFilePath, String(ledger));
+    } catch (err) {
+      this.logger.error('Failed to persist indexer cursor', err);
+    }
   }
 
   private async poll() {
@@ -30,17 +71,44 @@ export class IndexerService implements OnModuleInit {
         `Indexer: ${events.length} new event(s) from ledger ${this.lastProcessedLedger}`,
       );
 
+      let indexedCount = 0;
+      let maxLedger = this.lastProcessedLedger;
+
       for (const event of events) {
-        // TODO: upsert each event into the gists table via GistsService / TypeORM
-        this.logger.debug(`Indexed gist ${event.gistId} @ cell ${event.locationCell}`);
-        this.lastProcessedLedger = Math.max(this.lastProcessedLedger, event.createdAt);
+        try {
+          const { lat, lon } = this.geoService.decode(event.locationCell);
+
+          await this.gistRepository.upsertFromEvent({
+            stellar_gist_id: event.gistId,
+            location_cell: event.locationCell,
+            content_hash: event.contentHash,
+            lat,
+            lon,
+            created_at: new Date(event.createdAt * 1000),
+          });
+
+          maxLedger = Math.max(maxLedger, event.createdAt);
+          indexedCount++;
+
+          this.logger.debug(
+            `Indexed gist ${event.gistId} @ cell ${event.locationCell} (ledger ${event.createdAt})`,
+          );
+        } catch (eventErr) {
+          this.logger.error(
+            `Failed to index event for gist ${event.gistId} @ cell ${event.locationCell}`,
+            eventErr,
+          );
+        }
       }
+
+      if (maxLedger > this.lastProcessedLedger) {
+        this.lastProcessedLedger = maxLedger;
+        this.saveCursor(this.lastProcessedLedger);
+      }
+
+      this.logger.log(`Indexer: ${indexedCount}/${events.length} events upserted successfully`);
     } catch (err) {
       this.logger.error('Indexer poll failed', err);
     }
-  }
-
-  onModuleDestroy() {
-    if (this.pollInterval) clearInterval(this.pollInterval);
   }
 }

--- a/analytics/app/comparison/page.tsx
+++ b/analytics/app/comparison/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { jsPDF } from 'jspdf';
 import { useMemo, useState } from 'react';
 import ComparisonTable, { type ComparisonRow } from '@/components/ComparisonTable';
 
@@ -63,7 +62,14 @@ function downloadCsv(rows: ComparisonRow[], leftLabel: string, rightLabel: strin
   URL.revokeObjectURL(url);
 }
 
-function downloadPdf(rows: ComparisonRow[], leftLabel: string, rightLabel: string) {
+async function downloadPdf(rows: ComparisonRow[], leftLabel: string, rightLabel: string) {
+  let jsPDF: typeof import('jspdf').jsPDF;
+  try {
+    jsPDF = (await import('jspdf')).jsPDF;
+  } catch {
+    throw new Error('Failed to load PDF export library. Please try again.');
+  }
+
   const pdf = new jsPDF({ unit: 'mm', format: 'a4' });
 
   pdf.setFillColor(15, 23, 42);
@@ -101,6 +107,7 @@ export default function ComparisonPage() {
   const [currentEnd, setCurrentEnd] = useState('2026-03-28');
   const [previousStart, setPreviousStart] = useState('2026-02-01');
   const [previousEnd, setPreviousEnd] = useState('2026-02-28');
+  const [pdfError, setPdfError] = useState<string | null>(null);
 
   const currentMetrics = useMemo(
     () => generateMetrics(currentStart, currentEnd, 2),
@@ -187,7 +194,14 @@ export default function ComparisonPage() {
           </button>
           <button
             type="button"
-            onClick={() => downloadPdf(rows, currentLabel, previousLabel)}
+            onClick={async () => {
+              setPdfError(null);
+              try {
+                await downloadPdf(rows, currentLabel, previousLabel);
+              } catch (err) {
+                setPdfError(err instanceof Error ? err.message : 'PDF export failed');
+              }
+            }}
             style={{
               border: 'none',
               borderRadius: 999,
@@ -200,6 +214,11 @@ export default function ComparisonPage() {
           >
             Export PDF
           </button>
+          {pdfError && (
+            <span style={{ fontSize: 12, color: '#b91c1c', width: '100%', textAlign: 'right' }}>
+              {pdfError}
+            </span>
+          )}
         </div>
       </section>
 

--- a/analytics/components/ui/ChartExportCard.tsx
+++ b/analytics/components/ui/ChartExportCard.tsx
@@ -72,8 +72,12 @@ export default function ChartExportCard({ title, children }: ChartExportCardProp
             type="button"
             onClick={() =>
               withElement(async (element) => {
-                await downloadChartImage(title, element, background);
-                setStatus('PNG downloaded successfully.');
+                try {
+                  await downloadChartImage(title, element, background);
+                  setStatus('PNG downloaded successfully.');
+                } catch (error) {
+                  setStatus(error instanceof Error ? error.message : 'Download failed.');
+                }
               })
             }
             style={{

--- a/analytics/components/ui/ExcelExportButton.tsx
+++ b/analytics/components/ui/ExcelExportButton.tsx
@@ -4,12 +4,24 @@ import { useState } from 'react';
 import { downloadAnalyticsWorkbook } from '@/lib/excel-export';
 
 export default function ExcelExportButton() {
+  const [loading, setLoading] = useState(false);
   const [status, setStatus] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
-  const handleExport = () => {
-    downloadAnalyticsWorkbook();
-    setStatus('Workbook generated with Overview, Users, Locations, and Engagement sheets.');
-    window.setTimeout(() => setStatus(null), 1500);
+  const handleExport = async () => {
+    setLoading(true);
+    setError(null);
+    setStatus(null);
+
+    try {
+      await downloadAnalyticsWorkbook();
+      setStatus('Workbook generated with Overview, Users, Locations, and Engagement sheets.');
+      window.setTimeout(() => setStatus(null), 1500);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Export failed');
+    } finally {
+      setLoading(false);
+    }
   };
 
   return (
@@ -17,24 +29,31 @@ export default function ExcelExportButton() {
       <button
         type="button"
         onClick={handleExport}
+        disabled={loading}
         style={{
           border: 'none',
           borderRadius: 999,
-          background: '#166534',
+          background: loading ? '#a7f3d0' : '#166534',
           color: '#ffffff',
           padding: '12px 18px',
           fontSize: 14,
           fontWeight: 700,
-          cursor: 'pointer',
+          cursor: loading ? 'wait' : 'pointer',
           boxShadow: '0 12px 30px rgba(22,101,52,0.20)',
         }}
       >
-        Download Excel Workbook
+        {loading ? 'Generating...' : 'Download Excel Workbook'}
       </button>
 
       {status && (
         <span style={{ fontSize: 12, color: '#166534' }}>
           {status}
+        </span>
+      )}
+
+      {error && (
+        <span style={{ fontSize: 12, color: '#b91c1c' }}>
+          {error}
         </span>
       )}
     </div>

--- a/analytics/lib/chart-export.ts
+++ b/analytics/lib/chart-export.ts
@@ -1,5 +1,3 @@
-import html2canvas from 'html2canvas';
-
 export type ExportBackground = 'white' | 'transparent';
 
 function buildFilename(title: string) {
@@ -9,6 +7,13 @@ function buildFilename(title: string) {
 }
 
 async function captureElement(element: HTMLElement, background: ExportBackground) {
+  let html2canvas: typeof import('html2canvas').default;
+  try {
+    html2canvas = (await import('html2canvas')).default;
+  } catch {
+    throw new Error('Failed to load chart export library. Please try again.');
+  }
+
   return html2canvas(element, {
     scale: 2,
     backgroundColor: background === 'transparent' ? null : '#ffffff',

--- a/analytics/lib/excel.ts
+++ b/analytics/lib/excel.ts
@@ -1,4 +1,3 @@
-import * as XLSX from 'xlsx';
 import { categories, generateGistData } from '@/lib/utils';
 
 type CellValue = string | number;
@@ -40,7 +39,7 @@ function buildFilename() {
   return `vertexchain-analytics-${timestamp}.xlsx`;
 }
 
-function setColumnWidths(sheet: XLSX.WorkSheet, rows: CellValue[][]) {
+function setColumnWidths(sheet: import('xlsx').WorkSheet, rows: CellValue[][]) {
   const widths = rows[0].map((_, columnIndex) => {
     const max = rows.reduce((current, row) => {
       const value = row[columnIndex] == null ? '' : String(row[columnIndex]);
@@ -53,9 +52,9 @@ function setColumnWidths(sheet: XLSX.WorkSheet, rows: CellValue[][]) {
   sheet['!cols'] = widths;
 }
 
-function styleHeaderRow(sheet: XLSX.WorkSheet, columnCount: number) {
+function styleHeaderRow(sheet: import('xlsx').WorkSheet, columnCount: number, utils: import('xlsx').Utils) {
   for (let index = 0; index < columnCount; index += 1) {
-    const cellRef = XLSX.utils.encode_cell({ c: index, r: 0 });
+    const cellRef = utils.encode_cell({ c: index, r: 0 });
     const cell = sheet[cellRef];
 
     if (!cell) {
@@ -137,16 +136,25 @@ function createOverviewRows(
   ];
 }
 
-function rowsToSheet(name: string, rows: CellValue[][]) {
-  const sheet = XLSX.utils.aoa_to_sheet(rows);
+function rowsToSheet(name: string, rows: CellValue[][], utils: import('xlsx').Utils) {
+  const sheet = utils.aoa_to_sheet(rows);
 
   setColumnWidths(sheet, rows);
-  styleHeaderRow(sheet, rows[0]?.length ?? 0);
+  styleHeaderRow(sheet, rows[0]?.length ?? 0, utils);
 
   return { name, sheet };
 }
 
-export function downloadAnalyticsWorkbook() {
+export async function downloadAnalyticsWorkbook() {
+  let XLSX: typeof import('xlsx');
+  try {
+    XLSX = await import('xlsx');
+  } catch {
+    throw new Error('Failed to load Excel export library. Please try again.');
+  }
+
+  const { utils } = XLSX;
+
   const users = createUsersData(14);
   const locations = createLocationRows();
   const engagement = createEngagementRows();
@@ -165,16 +173,16 @@ export function downloadAnalyticsWorkbook() {
     ...engagement.map((row) => [row.gistId, row.category, row.ageDays, row.engagement]),
   ];
 
-  const workbook = XLSX.utils.book_new();
+  const workbook = utils.book_new();
   const sheets = [
-    rowsToSheet('Overview', overviewRows),
-    rowsToSheet('Users', usersRows),
-    rowsToSheet('Locations', locationsRows),
-    rowsToSheet('Engagement', engagementRows),
+    rowsToSheet('Overview', overviewRows, utils),
+    rowsToSheet('Users', usersRows, utils),
+    rowsToSheet('Locations', locationsRows, utils),
+    rowsToSheet('Engagement', engagementRows, utils),
   ];
 
   sheets.forEach(({ name, sheet }) => {
-    XLSX.utils.book_append_sheet(workbook, sheet, name);
+    utils.book_append_sheet(workbook, sheet, name);
   });
 
   XLSX.writeFile(workbook, buildFilename(), {

--- a/analytics/lib/export.ts
+++ b/analytics/lib/export.ts
@@ -1,5 +1,3 @@
-import Papa from 'papaparse';
-
 export type CsvValue = string | number | boolean | null | undefined;
 export type CsvRow = Record<string, CsvValue>;
 
@@ -101,6 +99,13 @@ export async function exportRowsToCsv({
         await yieldToBrowser();
       }
     }
+  }
+
+  let Papa: typeof import('papaparse').default;
+  try {
+    Papa = (await import('papaparse')).default;
+  } catch {
+    throw new Error('Failed to load CSV export library. Please try again.');
   }
 
   const csv = Papa.unparse(output);

--- a/analytics/lib/report.ts
+++ b/analytics/lib/report.ts
@@ -1,6 +1,3 @@
-import html2canvas from 'html2canvas';
-import jsPDF from 'jspdf';
-
 export interface ReportSection {
   title: string;
   element: HTMLElement;
@@ -36,6 +33,16 @@ export async function generatePdfReport(
   dateRange: string,
   onProgress?: (progress: number) => void,
 ) {
+  let jsPDF: typeof import('jspdf').default;
+  let html2canvas: typeof import('html2canvas').default;
+  try {
+    const jsPDFModule = await import('jspdf');
+    jsPDF = jsPDFModule.default;
+    html2canvas = (await import('html2canvas')).default;
+  } catch {
+    throw new Error('Failed to load PDF export library. Please try again.');
+  }
+
   const pdf = new jsPDF({
     format: 'a4',
     unit: 'mm',


### PR DESCRIPTION
## Summary

This PR resolves two issues:

### Issue #33: Lazy-load export libraries in analytics application

Replaced static imports with dynamic `import()` for papaparse, xlsx, html2canvas, and jspdf in all analytics export modules. These ~315KB of libraries are now loaded only on user click instead of on every page visit.

**Changes:**
- `analytics/lib/export.ts` — dynamic import of papaparse
- `analytics/lib/excel.ts` — dynamic import of xlsx
- `analytics/lib/chart-export.ts` — dynamic import of html2canvas
- `analytics/lib/report.ts` — dynamic imports of html2canvas and jspdf
- `analytics/app/comparison/page.tsx` — dynamic import of jspdf
- `analytics/components/ui/ExcelExportButton.tsx` — added loading state and error handling
- `analytics/components/ui/ChartExportCard.tsx` — added error handling for download

### Issue #14: Implement IndexerService to consume Soroban events and upsert to database

Implemented the TODO in IndexerService to actually upsert Soroban events into the gists table.

**Changes:**
- `Backend/src/indexer/indexer.service.ts` — added GistRepository and GeoService injection, implemented idempotent upsert per event, file-based cursor persistence for restart recovery, per-event error handling
- `Backend/src/indexer/indexer.module.ts` — imported TypeOrmModule.forFeature([Gist]), GeoModule, and GistRepository provider
- `Backend/src/gists/gist.repository.ts` — added findByStellarGistId() and upsertFromEvent() with ON CONFLICT upsert, decoded geohash to lat/lon via GeoService.decode()
- `Backend/src/gists/entities/gist.entity.ts` — added unique index on stellar_gist_id

Closes #33
Closes #14