### PR TITLE
chore: add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,77 @@
+name: "Bug report"
+description: "Use this form to file a reproducible bug report. Omit secrets; use private disclosure for sensitive security issues."
+title: "Bug: {{short_description}}"
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: "Thanks for taking the time to file a bug. Please provide clear, reproducible steps and environment details."
+
+  - type: input
+    id: short_description
+    attributes:
+      label: "Short summary"
+      description: "One-line summary of the bug"
+      placeholder: "e.g. Crash when saving project"
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: "Detailed description"
+      description: "Describe the bug in detail"
+      placeholder: "What happened?"
+      required: true
+
+  - type: textarea
+    id: steps_to_reproduce
+    attributes:
+      label: "Steps to reproduce"
+      description: "List the exact steps to reproduce the problem"
+      placeholder: "1. ...\n2. ...\n3. ..."
+      required: true
+
+  - type: textarea
+    id: expected_behavior
+    attributes:
+      label: "Expected behavior"
+      required: true
+
+  - type: textarea
+    id: actual_behavior
+    attributes:
+      label: "Actual behavior"
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: "Environment"
+      description: "OS, versions, browser, hardware, and other relevant environment details"
+      placeholder: "OS: Ubuntu 22.04\nApp version: v1.2.3\nNode: 18.x"
+      required: true
+
+  - type: checkboxes
+    id: attachments
+    attributes:
+      label: "Attachments"
+      options:
+        - label: "I have attached screenshots, logs, or a minimal repro"
+          value: "has_attachments"
+
+  - type: dropdown
+    id: security
+    attributes:
+      label: "Is this a security-sensitive issue?"
+      description: "If yes, do not include secrets or sensitive data here. Report privately to the project's security contact or follow the project's disclosure process."
+      options:
+        - label: "No"
+          value: "no"
+        - label: "Yes — I will disclose privately"
+          value: "yes"
+
+  - type: input
+    id: contact
+    attributes:
+      label: "Contact (optional)"
+      description: "Email or handle we can use to follow up if needed"

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,72 @@
+name: "Feature request"
+description: "Use this form to propose new features, enhancements, or improvements. Provide problem context and a proposed solution."
+title: "Feature: {{short_description}}"
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: "Thanks for proposing a feature. Clear problem statements and proposed solutions help maintainers evaluate requests quickly."
+
+  - type: input
+    id: short_description
+    attributes:
+      label: "Short summary"
+      description: "One-line summary of the feature proposal"
+      placeholder: "e.g. Add X to support Y"
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: "Problem"
+      description: "What problem are you trying to solve? Who is affected?"
+      placeholder: "Describe the current limitation or pain point"
+      required: true
+
+  - type: textarea
+    id: proposed_solution
+    attributes:
+      label: "Proposed solution"
+      description: "Describe the feature you'd like to see and how it would solve the problem"
+      placeholder: "Describe the design, API, UI changes, etc."
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: "Alternatives considered"
+      description: "Other approaches considered and why they were rejected"
+      placeholder: "Alternative A: ...\nAlternative B: ..."
+
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: "Additional context"
+      description: "Any other context, references, or screenshots that would help"
+
+  - type: dropdown
+    id: impact
+    attributes:
+      label: "Estimated impact"
+      description: "How important is this change?"
+      options:
+        - label: "High"
+          value: "high"
+        - label: "Medium"
+          value: "medium"
+        - label: "Low"
+          value: "low"
+
+  - type: checkboxes
+    id: attachments
+    attributes:
+      label: "Attachments"
+      options:
+        - label: "I have attached designs, mockups, or examples"
+          value: "has_attachments"
+
+  - type: input
+    id: contact
+    attributes:
+      label: "Contact (optional)"
+      description: "Email or handle we can use to follow up"

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+# Pull Request
+
+Please provide a short description of the change and link any related issues.
+
+## Description
+
+- Summary of changes
+- Related issue: # (if applicable)
+
+## Checklist
+
+- [ ] Tests added or updated
+- [ ] Documentation updated (README, docs, comments)
+- [ ] Linting passes
+- [ ] Type checking passes (if applicable)
+- [ ] Relevant issue linked
+- [ ] Changelog updated (if applicable)
+
+## Security
+
+If this change includes anything security-sensitive (secrets, auth changes, data exposure), describe mitigations and whether coordinated disclosure is required.
+
+## Notes for reviewers
+
+- Anything specific reviewers should check
+- How to run or reproduce the change locally


### PR DESCRIPTION

closes #30

Change: Added GitHub templates for issues and PRs.
Files:  .github/ISSUE_TEMPLATE/bug_report.yml,  .github/ISSUE_TEMPLATE/feature_request.yml,  .github/PULL_REQUEST_TEMPLATE.md
Format: Issue templates use GitHub issue form YAML (structured inputs).
Bug fields: short summary, detailed description, steps to reproduce, expected behavior, actual behavior, environment, attachments, security disclosure guidance, contact.
Feature fields: short summary, problem, proposed solution, alternatives, additional context, estimated impact, attachments, contact.
PR checklist: tests, docs, linting, type checking, linked issue, changelog; includes security notes and reviewer instructions.