### PR TITLE
style: auto-fix cargo fmt + terraform fmt (CI run #27889070577)

### DIFF
--- a/contracts/batch-wallet/src/lib.rs
+++ b/contracts/batch-wallet/src/lib.rs
@@ -107,7 +107,8 @@ impl BatchWalletEvents {
 
     pub fn wallet_recovered(env: &Env, old_owner: &Address, new_owner: &Address) {
         let topics = (symbol_short!("wallet"), symbol_short!("recovered"));
-        env.events().publish(topics, (old_owner.clone(), new_owner.clone()));
+        env.events()
+            .publish(topics, (old_owner.clone(), new_owner.clone()));
     }
 }
 
@@ -256,7 +257,7 @@ impl BatchWalletContract {
         for i in 0..requests.len() {
             let request = requests.get(i).unwrap();
             let owner = request.owner.clone();
-            
+
             // Check if this address was already seen in this batch
             for seen in seen_addresses.iter() {
                 if seen == owner {

--- a/contracts/governance/src/lib.rs
+++ b/contracts/governance/src/lib.rs
@@ -335,10 +335,10 @@ mod tests {
     fn test_initialize() {
         let env = Env::default();
         let admin = Address::generate(&env);
-        
+
         let contract_id = env.register(GovernanceContract, ());
         let client = GovernanceContractClient::new(&env, &contract_id);
-        
+
         client.initialize(&admin, 2);
         assert_eq!(client.get_admin(), admin);
     }
@@ -348,10 +348,10 @@ mod tests {
     fn test_cannot_initialize_twice() {
         let env = Env::default();
         let admin = Address::generate(&env);
-        
+
         let contract_id = env.register(GovernanceContract, ());
         let client = GovernanceContractClient::new(&env, &contract_id);
-        
+
         client.initialize(&admin, 2);
         client.initialize(&admin, 2);
     }
@@ -360,27 +360,27 @@ mod tests {
     fn test_create_and_execute_proposal() {
         let env = Env::default();
         env.mock_all_auths();
-        
+
         let admin = Address::generate(&env);
         let proposer = Address::generate(&env);
         let voter1 = Address::generate(&env);
         let voter2 = Address::generate(&env);
-        
+
         let contract_id = env.register(GovernanceContract, ());
         let client = GovernanceContractClient::new(&env, &contract_id);
-        
+
         client.initialize(&admin, 2);
-        
+
         let config_key = String::from_str(&env, "test_key");
         let config_value = String::from_str(&env, "test_value");
-        
+
         let proposal_id = client.create_proposal(&proposer, &config_key, &config_value, 1000);
-        
+
         client.vote_proposal(&voter1, proposal_id);
         client.vote_proposal(&voter2, proposal_id);
-        
+
         client.execute_proposal(&admin, proposal_id);
-        
+
         let retrieved_config = client.get_config(&config_key);
         assert_eq!(retrieved_config, Some(config_value));
     }

--- a/contracts/multisig/src/lib.rs
+++ b/contracts/multisig/src/lib.rs
@@ -395,10 +395,10 @@ mod tests {
     fn test_initialize() {
         let env = Env::default();
         let admin = Address::generate(&env);
-        
+
         let contract_id = env.register(MultisigContract, ());
         let client = MultisigContractClient::new(&env, &contract_id);
-        
+
         client.initialize(&admin);
         assert_eq!(client.get_admin(), admin);
     }
@@ -408,10 +408,10 @@ mod tests {
     fn test_cannot_initialize_twice() {
         let env = Env::default();
         let admin = Address::generate(&env);
-        
+
         let contract_id = env.register(MultisigContract, ());
         let client = MultisigContractClient::new(&env, &contract_id);
-        
+
         client.initialize(&admin);
         client.initialize(&admin);
     }
@@ -420,22 +420,22 @@ mod tests {
     fn test_set_signers() {
         let env = Env::default();
         env.mock_all_auths();
-        
+
         let admin = Address::generate(&env);
         let signer1 = Address::generate(&env);
         let signer2 = Address::generate(&env);
-        
+
         let contract_id = env.register(MultisigContract, ());
         let client = MultisigContractClient::new(&env, &contract_id);
-        
+
         client.initialize(&admin);
-        
+
         let mut signers = Vec::new(&env);
         signers.push_back(signer1.clone());
         signers.push_back(signer2.clone());
-        
+
         client.set_signers(&admin, &signers, 2);
-        
+
         let retrieved_signers = client.get_signers();
         assert_eq!(retrieved_signers.len(), 2);
         assert_eq!(client.get_threshold(), 2);

--- a/infrastructure/terraform/providers.tf
+++ b/infrastructure/terraform/providers.tf
@@ -14,8 +14,8 @@ provider "aws" {
 
   default_tags {
     tags = {
-      Project     = "vertexchain"
-      ManagedBy   = "terraform"
+      Project   = "vertexchain"
+      ManagedBy = "terraform"
     }
   }
 }

--- a/infrastructure/terraform/rds.tf
+++ b/infrastructure/terraform/rds.tf
@@ -30,9 +30,9 @@ resource "aws_db_instance" "postgres" {
   vpc_security_group_ids = [aws_security_group.db.id]
   parameter_group_name   = aws_db_parameter_group.postgres.name
 
-  backup_retention_period = 7
-  monitoring_interval     = 60
-  skip_final_snapshot     = false
+  backup_retention_period   = 7
+  monitoring_interval       = 60
+  skip_final_snapshot       = false
   final_snapshot_identifier = "${var.project_name}-${var.environment}-final"
 
   tags = { Environment = var.environment, Project = var.project_name }

--- a/infrastructure/terraform/secrets-manager.tf
+++ b/infrastructure/terraform/secrets-manager.tf
@@ -1,4 +1,4 @@
-﻿# Secrets Manager for centralized secrets storage
+# Secrets Manager for centralized secrets storage
 resource "aws_secretsmanager_secret" "app_secret" {
   name                    = "${var.app_name}-${var.environment}-secret"
   description             = "Application secrets for ${var.environment}"

--- a/infrastructure/terraform/tags.tf
+++ b/infrastructure/terraform/tags.tf
@@ -1,4 +1,4 @@
-﻿# Standard tag schema for cost tracking and resource management
+# Standard tag schema for cost tracking and resource management
 locals {
   common_tags = {
     Project     = var.project_name

--- a/infrastructure/terraform/waf.tf
+++ b/infrastructure/terraform/waf.tf
@@ -1,4 +1,4 @@
-﻿# WAF for application protection
+# WAF for application protection
 resource "aws_wafv2_web_acl" "app_waf" {
   name  = "${var.app_name}-${var.environment}-waf"
   scope = "REGIONAL"

--- a/infrastructure/terraform/workspaces.tf
+++ b/infrastructure/terraform/workspaces.tf
@@ -1,4 +1,4 @@
-﻿# Multi-environment workspace configuration
+# Multi-environment workspace configuration
 locals {
   env_config = {
     dev = {


### PR DESCRIPTION
CI run #27889070577 — driven by the smoke test in PR #62 — surfaced formatting drift in the Contracts workspace (Rust) and the Terraform directory. Auto-applied via `cargo fmt --all` and `terraform fmt -recursive` respectively. Pure formatting; no logic change.

Two separate commits so each formatters drift is independently revertable if needed.