### PR TITLE
fix: update Footer to reference Stellar Network instead of Flare Network

### DIFF
--- a/Frontend/src/components/landing/Footer.tsx
+++ b/Frontend/src/components/landing/Footer.tsx
@@ -6,7 +6,10 @@ export function Footer() {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <div className="flex flex-col md:flex-row items-center justify-between gap-4">
           <p className="text-sm text-[--text-muted]">
-            &copy; {new Date().getFullYear()} VertexChain. Powered by the Flare Network.
+            &copy; {new Date().getFullYear()} VertexChain. Powered by the{' '}
+            <a href="https://stellar.org" target="_blank" rel="noopener noreferrer" className="hover:text-[--text-primary] transition-colors">
+              Stellar Network
+            </a>.
           </p>
           <nav aria-label="Footer navigation" className="flex items-center gap-6">
             <Link href="/privacy" className="text-sm text-[--text-muted] hover:text-[--text-primary] transition-colors">


### PR DESCRIPTION


## Summary
Fixes incorrect branding in the Footer component. The platform runs on
Stellar/Soroban but the footer stated "Powered by the Flare Network".

## Changes
- Updated footer text from "Flare Network" to "Stellar Network"
- Added link to https://stellar.org
- Year remains dynamically rendered
- All nav links (Privacy, Terms, Docs) preserved
- Layout/styling unchanged

Closes #21
