### PR TITLE
perf(backend): add brotli-preferred response compression middleware (#43)

### DIFF
--- a/Backend/src/common/middleware/compression.middleware.spec.ts
+++ b/Backend/src/common/middleware/compression.middleware.spec.ts
@@ -1,0 +1,403 @@
+import { Buffer } from 'buffer';
+import { Request, Response } from 'express';
+import { brotliDecompressSync, gunzipSync } from 'zlib';
+import { compressionMiddleware } from './compression.middleware';
+
+type MockResponse = Response & {
+  getEmittedBody(): Promise<Buffer>;
+};
+
+/**
+ * Build a plain JS-object mock of Express's Response. Avoids Node PassThrough
+ * entirely so we have deterministic, synchronous-feeling byte capture.
+ *
+ * `res.write` / `res.end` chunk into a buffer. The mock's write is captured
+ * by the middleware via `res.write.bind(res)` BEFORE the middleware replaces
+ * `res.write` with its compressor override — so when the compressor calls
+ * the *original* write, our buffer accumulates the wire payload.
+ */
+function buildResMock(contentType?: string): { res: MockResponse } {
+  const chunks: Buffer[] = [];
+  const headerBag: Record<string, string> = {};
+  if (contentType) headerBag['content-type'] = contentType;
+
+  let resolveBody!: (body: Buffer) => void;
+  const bodyPromise = new Promise<Buffer>((resolve) => {
+    resolveBody = resolve;
+  });
+
+  const res = {
+    statusCode: 200,
+    headersSent: false,
+    setHeader(name: string, value: string | number | string[]): void {
+      headerBag[name.toLowerCase()] = String(value);
+    },
+    getHeader(name: string): string | number | string[] | undefined {
+      return headerBag[name.toLowerCase()];
+    },
+    hasHeader(name: string): boolean {
+      return name.toLowerCase() in headerBag;
+    },
+    removeHeader(name: string): void {
+      delete headerBag[name.toLowerCase()];
+    },
+    write(
+      chunk: Buffer | string | Uint8Array,
+      encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void),
+      callback?: (error?: Error | null) => void,
+    ): boolean {
+      const buf =
+        typeof chunk === 'string'
+          ? Buffer.from(chunk, typeof encodingOrCallback === 'string' ? encodingOrCallback : 'utf8')
+          : Buffer.from(chunk instanceof Uint8Array ? chunk : Buffer.from(chunk));
+
+      chunks.push(buf);
+
+      const cb = typeof encodingOrCallback === 'function' ? encodingOrCallback : callback;
+      if (cb) cb();
+      return true;
+    },
+    end(
+      chunk?: Buffer | string | Uint8Array,
+      encodingOrCallback?: BufferEncoding | (() => void),
+      callback?: () => void,
+    ): MockResponse {
+      if (chunk) {
+        const buf =
+          typeof chunk === 'string'
+            ? Buffer.from(
+                chunk,
+                typeof encodingOrCallback === 'string' ? encodingOrCallback : 'utf8',
+              )
+            : Buffer.from(chunk instanceof Uint8Array ? chunk : Buffer.from(chunk));
+        chunks.push(buf);
+      }
+
+      resolveBody(Buffer.concat(chunks));
+      resolveBody = undefined as unknown as (body: Buffer) => void;
+
+      const cb = typeof encodingOrCallback === 'function' ? encodingOrCallback : callback;
+      if (cb) cb();
+      return res;
+    },
+    once(_event: string, _listener: (...args: unknown[]) => void): void {
+      // Stash the close listener so tests can drive unmount/disconnect
+      // simulation without going through a real PassThrough.
+      (res as { _closeListeners?: Array<() => void> })._closeListeners = (
+        (res as { _closeListeners?: Array<() => void> })._closeListeners ?? []
+      ).concat(() => _listener());
+    },
+    emit(event: string): boolean {
+      if (event !== 'close') return false;
+      const listeners = (res as { _closeListeners?: Array<() => void> })._closeListeners ?? [];
+      for (const listener of listeners) listener();
+      listeners.length = 0;
+      return true;
+    },
+    getEmittedBody(): Promise<Buffer> {
+      return bodyPromise;
+    },
+  } as unknown as MockResponse;
+
+  return { res };
+}
+
+function buildReq(path: string, acceptEncoding?: string, method = 'GET'): Request {
+  return {
+    path,
+    method,
+    headers: acceptEncoding ? { 'accept-encoding': acceptEncoding } : {},
+  } as unknown as Request;
+}
+
+describe('compressionMiddleware (unit)', () => {
+  describe('path / method skips', () => {
+    it('does not compress /health even when the client requests brotli', () => {
+      const next = jest.fn();
+      const { res } = buildResMock('application/json');
+      compressionMiddleware(buildReq('/health', 'br, gzip'), res, next);
+      expect(res.getHeader('Content-Encoding')).toBeUndefined();
+      expect(res.getHeader('Vary')).toBe('Accept-Encoding');
+      expect(next).toHaveBeenCalled();
+    });
+
+    it('does not compress /csrf-token', () => {
+      const next = jest.fn();
+      const { res } = buildResMock('application/json');
+      compressionMiddleware(buildReq('/csrf-token', 'br, gzip'), res, next);
+      expect(res.getHeader('Content-Encoding')).toBeUndefined();
+      expect(next).toHaveBeenCalled();
+    });
+
+    it('does not compress HEAD requests', () => {
+      const next = jest.fn();
+      const { res } = buildResMock('application/json');
+      compressionMiddleware(buildReq('/gists', 'br, gzip', 'HEAD'), res, next);
+      expect(res.getHeader('Content-Encoding')).toBeUndefined();
+      expect(next).toHaveBeenCalled();
+    });
+
+    it('does not compress OPTIONS requests', () => {
+      const next = jest.fn();
+      const { res } = buildResMock('application/json');
+      compressionMiddleware(buildReq('/gists', 'br, gzip', 'OPTIONS'), res, next);
+      expect(res.getHeader('Content-Encoding')).toBeUndefined();
+      expect(next).toHaveBeenCalled();
+    });
+
+    it('still emits Vary: Accept-Encoding for skipped routes (cache safety)', () => {
+      const next = jest.fn();
+      const { res } = buildResMock('application/json');
+      compressionMiddleware(buildReq('/health', 'br, gzip'), res, next);
+      expect(res.getHeader('Vary')).toBe('Accept-Encoding');
+    });
+  });
+
+  describe('Accept-Encoding negotiation', () => {
+    it('prefers brotli when both br and gzip are advertised', async () => {
+      const next = jest.fn();
+      const { res } = buildResMock('application/json');
+      compressionMiddleware(buildReq('/gists', 'gzip, deflate, br'), res, next);
+
+      const payload = { hello: 'world', items: [1, 2, 3] };
+      res.end(JSON.stringify(payload));
+
+      expect(res.getHeader('Content-Encoding')).toBe('br');
+
+      const compressed = await res.getEmittedBody();
+      expect(compressed.length).toBeGreaterThan(0);
+
+      const decoded = brotliDecompressSync(compressed).toString('utf8');
+      expect(JSON.parse(decoded)).toEqual(payload);
+    });
+
+    it('falls back to gzip when brotli is not advertised', async () => {
+      const next = jest.fn();
+      const { res } = buildResMock('application/json');
+      compressionMiddleware(buildReq('/gists', 'gzip, deflate'), res, next);
+
+      const payload = { hello: 'world', repeated: 'a'.repeat(200) };
+      res.end(JSON.stringify(payload));
+
+      expect(res.getHeader('Content-Encoding')).toBe('gzip');
+
+      const compressed = await res.getEmittedBody();
+      const decoded = gunzipSync(compressed).toString('utf8');
+      expect(JSON.parse(decoded)).toEqual(payload);
+    });
+
+    it('emits no Content-Encoding when only identity is supported', async () => {
+      const next = jest.fn();
+      const { res } = buildResMock('application/json');
+      compressionMiddleware(buildReq('/gists', 'identity'), res, next);
+
+      res.end('{}');
+      await res.getEmittedBody();
+
+      expect(res.getHeader('Content-Encoding')).toBeUndefined();
+      expect(res.getHeader('Vary')).toBe('Accept-Encoding');
+    });
+
+    it('emits no Content-Encoding when no Accept-Encoding header is sent', async () => {
+      const next = jest.fn();
+      const { res } = buildResMock('application/json');
+      compressionMiddleware(buildReq('/gists'), res, next);
+
+      res.end('{}');
+      await res.getEmittedBody();
+
+      expect(res.getHeader('Content-Encoding')).toBeUndefined();
+      expect(res.getHeader('Vary')).toBe('Accept-Encoding');
+    });
+
+    it('picks gzip when q-values favor gzip over brotli', async () => {
+      const next = jest.fn();
+      const { res } = buildResMock('application/json');
+      compressionMiddleware(buildReq('/gists', 'br;q=0.1, gzip;q=0.9'), res, next);
+
+      res.end(JSON.stringify({ a: 'a'.repeat(50) }));
+      await res.getEmittedBody();
+
+      expect(res.getHeader('Content-Encoding')).toBe('gzip');
+    });
+
+    it('treats q=0 as disabled (selects br even when br is later in the header)', async () => {
+      const next = jest.fn();
+      const { res } = buildResMock('application/json');
+      compressionMiddleware(buildReq('/gists', 'gzip;q=0, br'), res, next);
+
+      res.end(JSON.stringify({ a: 'a'.repeat(50) }));
+      await res.getEmittedBody();
+
+      expect(res.getHeader('Content-Encoding')).toBe('br');
+    });
+
+    it('tolerates whitespace around q= (RFC 7231 OWS)', async () => {
+      const next = jest.fn();
+      const { res } = buildResMock('application/json');
+      compressionMiddleware(buildReq('/gists', 'gzip; q = 0.1, br ;q=0.9 '), res, next);
+
+      res.end(JSON.stringify({ a: 'a'.repeat(50) }));
+      await res.getEmittedBody();
+
+      expect(res.getHeader('Content-Encoding')).toBe('br');
+    });
+
+    it('falls back to brotli for the wildcard "*" when no explicit coding', () => {
+      const next = jest.fn();
+      const { res } = buildResMock('application/json');
+      compressionMiddleware(buildReq('/gists', '*'), res, next);
+
+      res.end('{}');
+
+      expect(res.getHeader('Content-Encoding')).toBe('br');
+    });
+
+    it('does not compress anything when both br and gzip are disabled via q=0', async () => {
+      const next = jest.fn();
+      const { res } = buildResMock('application/json');
+      compressionMiddleware(buildReq('/gists', 'br;q=0, gzip;q=0'), res, next);
+
+      res.end('{}');
+      await res.getEmittedBody();
+
+      expect(res.getHeader('Content-Encoding')).toBeUndefined();
+      expect(res.getHeader('Vary')).toBe('Accept-Encoding');
+    });
+
+    it('does not let the * wildcard override an explicit q=0 (RFC 7231)', async () => {
+      const next = jest.fn();
+      const { res } = buildResMock('application/json');
+      // Client explicitly refuses br (q=0) but allows anything else via *.
+      // Per RFC 7231, the explicit q=0 must stick for br, and the wildcard
+      // applies gzip at implicit q=1 — so gzip wins.
+      compressionMiddleware(buildReq('/gists', 'br;q=0, *'), res, next);
+
+      res.end('{}');
+      await res.getEmittedBody();
+
+      expect(res.getHeader('Content-Encoding')).toBe('gzip');
+    });
+  });
+
+  describe('Content-Type policy', () => {
+    it('skips compression for image/png payloads', async () => {
+      const next = jest.fn();
+      const { res } = buildResMock('image/png');
+      compressionMiddleware(buildReq('/gists', 'br, gzip'), res, next);
+
+      const pngBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+      res.end(pngBytes);
+
+      await res.getEmittedBody();
+      expect(res.getHeader('Content-Encoding')).toBeUndefined();
+    });
+
+    it('skips compression for 204 No Content', async () => {
+      const next = jest.fn();
+      const { res } = buildResMock('application/json');
+      (res as { statusCode: number }).statusCode = 204;
+      compressionMiddleware(buildReq('/gists', 'br, gzip'), res, next);
+
+      // 204 must never carry a body — so even though we hand bytes in, the
+      // middleware must short-circuit before the compressor starts.
+      res.end();
+
+      await res.getEmittedBody();
+      expect(res.getHeader('Content-Encoding')).toBeUndefined();
+    });
+
+    it('drops body bytes for 204 No Content even if the controller writes them', async () => {
+      const next = jest.fn();
+      const { res } = buildResMock('application/json');
+      (res as { statusCode: number }).statusCode = 204;
+      compressionMiddleware(buildReq('/gists', 'br, gzip'), res, next);
+
+      // Controller attempts to attach a body to the 204 — middleware must
+      // drop the bytes (RFC 7230 §3.3.1) regardless of negotiation outcome.
+      res.end('{"status":"ok"}');
+
+      const emitted = await res.getEmittedBody();
+      expect(emitted.length).toBe(0);
+      expect(res.getHeader('Content-Encoding')).toBeUndefined();
+      expect(res.getHeader('Content-Length')).toBeUndefined();
+    });
+
+    it('compresses text/html payloads with brotli', async () => {
+      const next = jest.fn();
+      const { res } = buildResMock('text/html; charset=utf-8');
+      compressionMiddleware(buildReq('/gists', 'br, gzip'), res, next);
+
+      const html = '<!doctype html>' + '<p>hello world</p>'.repeat(50);
+      res.end(html);
+
+      expect(res.getHeader('Content-Encoding')).toBe('br');
+
+      const compressed = await res.getEmittedBody();
+      const decoded = brotliDecompressSync(compressed).toString('utf8');
+      expect(decoded).toContain('<!doctype html>');
+      expect(decoded.length).toBe(html.length);
+    });
+  });
+
+  describe('streaming fidelity', () => {
+    it('streams multi-chunk bodies through the compressor without losing data', async () => {
+      const next = jest.fn();
+      const { res } = buildResMock('application/json');
+      compressionMiddleware(buildReq('/gists', 'br'), res, next);
+
+      const payload = { items: Array.from({ length: 50 }, (_, i) => ({ i })) };
+      const text = JSON.stringify(payload);
+      const head = text.slice(0, 30);
+      const middle = text.slice(30, -2);
+      const tail = text.slice(-2);
+
+      res.write(head);
+      res.write(middle);
+      res.end(tail);
+
+      expect(res.getHeader('Content-Encoding')).toBe('br');
+
+      const compressed = await res.getEmittedBody();
+      const decoded = brotliDecompressSync(compressed).toString('utf8');
+      expect(JSON.parse(decoded)).toEqual(payload);
+    });
+
+    it('removes Content-Length when compressing', async () => {
+      const next = jest.fn();
+      const { res } = buildResMock('application/json');
+      res.setHeader('Content-Length', '9999');
+      compressionMiddleware(buildReq('/gists', 'gzip'), res, next);
+
+      res.end(JSON.stringify({ a: 'a'.repeat(500) }));
+      await res.getEmittedBody();
+
+      // False pre-compression size must never reach ALB — drop it.
+      expect(res.getHeader('Content-Length')).toBeUndefined();
+      expect(res.getHeader('Content-Encoding')).toBe('gzip');
+    });
+  });
+
+  describe('Reduce wire size', () => {
+    it('produces a smaller wire body for repetitive JSON', async () => {
+      const text = 'lorem ipsum dolor sit amet, consectetur adipiscing elit. ';
+      const payload = JSON.stringify({ body: text.repeat(200) });
+      const raw = Buffer.from(payload, 'utf8');
+
+      const { res: resGzip } = buildResMock('application/json');
+      compressionMiddleware(buildReq('/gists', 'gzip'), resGzip, jest.fn());
+      resGzip.end(payload);
+      const gzipWire = await resGzip.getEmittedBody();
+
+      expect(gzipWire.length).toBeLessThan(raw.length);
+      expect(gzipWire.length).toBeLessThan(raw.length / 2);
+
+      // And brotli should compress at least as well.
+      const { res: resBr } = buildResMock('application/json');
+      compressionMiddleware(buildReq('/gists', 'br'), resBr, jest.fn());
+      resBr.end(payload);
+      const brWire = await resBr.getEmittedBody();
+      expect(brWire.length).toBeLessThan(raw.length);
+    });
+  });
+});

--- a/Backend/src/common/middleware/compression.middleware.ts
+++ b/Backend/src/common/middleware/compression.middleware.ts
@@ -1,0 +1,317 @@
+import { Request, Response, NextFunction } from 'express';
+import { createBrotliCompress, createGzip, BrotliCompress, Gzip } from 'zlib';
+
+/**
+ * Response compression middleware.
+ *
+ * Satisfies GitHub Issue #43 acceptance criteria:
+ *   - Prefers `br` (Brotli) over `gzip` via Accept-Encoding negotiation,
+ *     honoring q-values per RFC 7231 (q=0 disables the encoding), with
+ *     explicit `q=0` overriding any implicit wildcard.
+ *   - Skips health-check endpoints so liveness probes never buffer.
+ *   - Handles streaming responses (no full-body buffering) by piping
+ *     through a zlib Transform stream.
+ *   - Avoids compressing upstream-compressed payloads (images, fonts,
+ *     already-encoded binaries) by inspecting Content-Type.
+ *   - Sets `Vary: Accept-Encoding` on every response (compressed or not)
+ *     so CDNs / reverse proxies cache correctly.
+ *   - Preserves the `res.write` backpressure signal — callers see the
+ *     same boolean return value they would emit without compression
+ *     (whether or not a zlib Transform is in the path).
+ *   - Reclaims the zlib Transform's internal buffers on completion,
+ *     on compressor error, or on premature client disconnect.
+ *   - Drops downstream body bytes for 204 / 304 so callers can't
+ *     accidentally violate RFC 7230 §3.3.1.
+ *
+ * Implemented against Node's built-in `zlib` so we don't pull in the
+ * `compression` npm package (which only supports deflate/gzip and has no
+ * native Brotli).
+ */
+
+/**
+ * Paths whose body is never compressed. `/health` is universal for
+ * ALB/ELB liveness probes; `/csrf-token` is a tiny JSON whose compression
+ * overhead exceeds the benefit. Add more here as new probe-style routes
+ * appear.
+ */
+const DEFAULT_SKIP_PATHS = new Set<string>(['/health', '/csrf-token']);
+
+/**
+ * Content-Type patterns we are willing to compress. Anything outside this
+ * set — images, videos, fonts, already-gzipped binaries — flows through
+ * untouched.
+ */
+const COMPRESSIBLE_CONTENT_TYPE =
+  /^text\/|^application\/(json|xml|javascript|ld\+json|x-javascript|wasm)|^image\/svg\+xml/i;
+
+/** Per RFC 7230 §3.3.1, these statuses must not carry a body. */
+const NO_COMPRESSION_STATUS_CODES = new Set([204, 304]);
+
+interface AcceptEncodingToken {
+  coding: string;
+  q: number;
+}
+
+/**
+ * Tokenize an Accept-Encoding header per RFC 7231 §5.3.4:
+ *   Accept-Encoding = #( codings [ weight ] )
+ *   weight          = OWS ";" OWS "q=" Q-value
+ *   Q-value         = "0" [ "." 0-3DIGIT ] / "1" [ "." 0-3("0") ]
+ * Tokens with an invalid q-value fall back to the default of 1.0.
+ */
+function tokenizeAcceptEncoding(header: string | undefined): AcceptEncodingToken[] {
+  if (!header) return [];
+
+  return header
+    .split(',')
+    .map((raw) => raw.trim())
+    .filter((token) => token.length > 0)
+    .map<AcceptEncodingToken>((token) => {
+      const parts = token.split(';').map((p) => p.trim());
+      const coding = parts[0]?.toLowerCase() ?? '';
+      let q = 1;
+      for (const param of parts.slice(1)) {
+        // RFC 7231 allows OWS inside the weight, e.g. "q = 0.5".
+        // Split on '=' so `q`, `=`, value are independent of whitespace.
+        const eqIndex = param.indexOf('=');
+        if (eqIndex === -1) continue;
+        const name = param.slice(0, eqIndex).trim().toLowerCase();
+        if (name !== 'q') continue;
+        const value = param.slice(eqIndex + 1).trim();
+        const parsed = Number.parseFloat(value);
+        if (Number.isFinite(parsed) && parsed >= 0 && parsed <= 1) {
+          q = parsed;
+        }
+      }
+      return { coding, q };
+    });
+}
+
+/**
+ * Pick the best encoding the client will accept. Returns null when:
+ *   - the only acceptable coding is `identity`,
+ *   - all of our supported codings (`br`, `gzip`) are explicitly disabled
+ *     via `q=0`,
+ *   - the header lists nothing we support (including `*`).
+ *
+ * Among `br` and `gzip`, the higher q wins; ties prefer `br` so the
+ * issue's "Must prefer brotli over gzip" rule holds even with equal q.
+ * `*` is a wildcard that implies q=1 for everything we support; an
+ * explicit `q=0` has higher precedence than the wildcard.
+ */
+function negotiateEncoding(header: string | undefined): 'br' | 'gzip' | null {
+  const tokens = tokenizeAcceptEncoding(header);
+
+  const qByCoding: Record<'br' | 'gzip', number> = { br: 0, gzip: 0 };
+  const explicit: Record<'br' | 'gzip', boolean> = { br: false, gzip: false };
+  let hasWildcard = false;
+  for (const { coding, q } of tokens) {
+    if (coding === '*') {
+      hasWildcard = true;
+      continue;
+    }
+    if (coding === 'br' || coding === 'gzip') {
+      qByCoding[coding] = q;
+      explicit[coding] = true;
+    }
+  }
+
+  if (hasWildcard) {
+    if (!explicit.br) qByCoding.br = 1;
+    if (!explicit.gzip) qByCoding.gzip = 1;
+  }
+
+  if (qByCoding.br === 0 && qByCoding.gzip === 0) return null;
+  if (qByCoding.br === 0) return 'gzip';
+  if (qByCoding.gzip === 0) return 'br';
+  if (qByCoding.br === qByCoding.gzip) return 'br'; // tie -> brotli preferred
+  return qByCoding.br > qByCoding.gzip ? 'br' : 'gzip';
+}
+
+function shouldCompressContentType(contentType: string | undefined): boolean {
+  if (!contentType) return true; // assume compressible if unknown
+  return COMPRESSIBLE_CONTENT_TYPE.test(contentType);
+}
+
+export function compressionMiddleware(req: Request, res: Response, next: NextFunction): void {
+  // Express sets `req.path`; raw Node http does not. Derive a usable path
+  // from `req.url` when Express hasn't populated it so /health and
+  // /csrf-token stay correctly excluded outside of NestJS.
+  const requestPath =
+    typeof req.path === 'string' ? req.path : ((req.url ?? '/').split('?')[0] ?? '/');
+
+  // Health probes and preflight requests never get compressed.
+  // We still emit Vary so caches don't mix compressed and uncompressed variants.
+  if (DEFAULT_SKIP_PATHS.has(requestPath) || req.method === 'HEAD' || req.method === 'OPTIONS') {
+    res.setHeader('Vary', 'Accept-Encoding');
+    return next();
+  }
+
+  // Set Vary on every response so intermediate caches respect Accept-Encoding.
+  res.setHeader('Vary', 'Accept-Encoding');
+
+  const encoding = negotiateEncoding(req.headers['accept-encoding'] as string | undefined);
+  if (!encoding) return next();
+
+  const originalWrite = res.write.bind(res);
+  const originalEnd = res.end.bind(res);
+
+  let stream: BrotliCompress | Gzip | null = null;
+  let noBody = false;
+  let initialized = false;
+  let ended = false;
+
+  const initStream = (): { stream: BrotliCompress | Gzip | null; noBody: boolean } => {
+    if (initialized) return { stream, noBody };
+    initialized = true;
+
+    // No-content statuses must never carry a body, even if a controller
+    // accidentally calls res.write/end with one. RFC 7230 §3.3.1 forbids
+    // any message body for 204 / 304; we honor that at the byte layer.
+    if (NO_COMPRESSION_STATUS_CODES.has(res.statusCode)) {
+      noBody = true;
+      res.removeHeader('Content-Length');
+      return { stream: null, noBody };
+    }
+
+    const rawContentType = res.getHeader('Content-Type');
+    const contentType = Array.isArray(rawContentType)
+      ? rawContentType.join(';')
+      : (rawContentType as string | undefined);
+
+    if (!shouldCompressContentType(contentType)) {
+      return { stream: null, noBody };
+    }
+
+    stream = encoding === 'br' ? createBrotliCompress() : createGzip();
+
+    // Compression changes wire size — drop Content-Length so Express emits
+    // Transfer-Encoding: chunked. ALB rejects responses that advertise a
+    // pre-compression Content-Length.
+    res.removeHeader('Content-Length');
+    res.setHeader('Content-Encoding', encoding);
+
+    stream.on('data', (chunk: Buffer) => {
+      originalWrite(chunk);
+    });
+    stream.on('end', () => {
+      if (ended) return;
+      ended = true;
+      // Drop internal buffers so GC can reclaim the Transform promptly.
+      stream?.destroy();
+      originalEnd();
+    });
+    stream.on('error', (err: Error) => {
+      // A compressor failure must never reach the client as a partially-
+      // valid compressed stream — a decompressor would emit gibberish.
+      // Tear down the socket so NestJS exception filters surface the
+      // failure as a real 500 rather than a silent truncation.
+      if (ended) return;
+      ended = true;
+      stream?.destroy();
+      res.destroy(err);
+    });
+
+    // If the client disconnects mid-stream, the compressor's 'end' never
+    // fires. Reclaim the Transform's internal buffers promptly to avoid
+    // a per-request leak.
+    res.once('close', () => {
+      if (ended) return;
+      ended = true;
+      stream?.destroy();
+    });
+
+    return { stream, noBody };
+  };
+
+  // res.write has two overloads (chunk+cb) and (chunk+encoding+cb). We
+  // express the override with the same shape to stay type-safe.
+  const writeOverride: typeof res.write = function write(
+    chunk: any,
+    encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void),
+    callback?: (error?: Error | null) => void,
+  ): boolean {
+    const { stream: activeStream, noBody: dropBody } = initStream();
+
+    if (dropBody) {
+      // 204 / 304 — swallow the chunk but preserve the boolean contract
+      // so upstream callers throttle exactly as they would normally.
+      const cb = typeof encodingOrCallback === 'function' ? encodingOrCallback : callback;
+      if (cb) cb();
+      return true;
+    }
+
+    if (!activeStream) {
+      if (typeof encodingOrCallback === 'function') {
+        return originalWrite(chunk, encodingOrCallback);
+      }
+      if (typeof encodingOrCallback === 'string') {
+        return originalWrite(chunk, encodingOrCallback, callback);
+      }
+      return originalWrite(chunk);
+    }
+
+    if (typeof encodingOrCallback === 'function') {
+      return activeStream.write(chunk, encodingOrCallback);
+    }
+    if (typeof encodingOrCallback === 'string') {
+      return activeStream.write(chunk, encodingOrCallback, callback);
+    }
+    return activeStream.write(chunk);
+  };
+
+  const endOverride: typeof res.end = function end(
+    chunk?: any,
+    encodingOrCallback?: BufferEncoding | (() => void),
+    callback?: () => void,
+  ): Response {
+    const { stream: activeStream, noBody: dropBody } = initStream();
+
+    if (dropBody) {
+      // No bytes on the wire — forward only the callback, drop chunk and
+      // encoding. Express then sends a status-only 204/304 with no
+      // Transfer-Encoding chunked trailer.
+      const cb = typeof encodingOrCallback === 'function' ? encodingOrCallback : callback;
+      if (cb) {
+        return originalEnd(cb);
+      }
+      return originalEnd();
+    }
+
+    if (!activeStream) {
+      if (typeof encodingOrCallback === 'function') {
+        return originalEnd(chunk, encodingOrCallback);
+      }
+      if (typeof encodingOrCallback === 'string') {
+        return originalEnd(chunk, encodingOrCallback, callback);
+      }
+      return originalEnd(chunk);
+    }
+
+    if (chunk) {
+      if (typeof encodingOrCallback === 'function') {
+        activeStream.end(chunk, encodingOrCallback);
+      } else if (typeof encodingOrCallback === 'string') {
+        activeStream.end(chunk, encodingOrCallback, callback);
+      } else {
+        activeStream.end(chunk);
+      }
+    } else {
+      if (typeof encodingOrCallback === 'function') {
+        activeStream.end(encodingOrCallback);
+      } else if (typeof encodingOrCallback === 'string') {
+        activeStream.end(encodingOrCallback, callback);
+      } else if (callback) {
+        activeStream.end(callback);
+      } else {
+        activeStream.end();
+      }
+    }
+    return res;
+  };
+
+  res.write = writeOverride;
+  res.end = endOverride;
+
+  next();
+}

--- a/Backend/src/main.ts
+++ b/Backend/src/main.ts
@@ -9,9 +9,17 @@ import {
   csrfErrorHandler,
   csrfProtection,
 } from './common/middleware/csrf.middleware';
+import { compressionMiddleware } from './common/middleware/compression.middleware';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  // Issue 43 — Response compression.
+  // Registered first so the middleware wraps `res.write` / `res.end`
+  // before CORS, CSRF, validation, and the NestJS controllers run. Every
+  // downstream handler writes through the compressor; CORS preflights
+  // (OPTIONS) are skipped ahead of all handlers via `req.method`.
+  app.use(compressionMiddleware);
 
   // Issue 78 — CORS
   const allowedOrigins = process.env.CORS_ORIGINS

--- a/Backend/test/compression.e2e-spec.ts
+++ b/Backend/test/compression.e2e-spec.ts
@@ -1,0 +1,213 @@
+import * as http from 'http';
+import type { IncomingMessage, ServerResponse } from 'http';
+import * as request from 'supertest';
+import { brotliDecompressSync, gunzipSync } from 'zlib';
+import { compressionMiddleware } from '../src/common/middleware/compression.middleware';
+
+type Handler = (req: IncomingMessage, res: ServerResponse) => void;
+type Routes = Record<string, Handler>;
+type Middleware = (req: IncomingMessage, res: ServerResponse, next: () => void) => void;
+
+/**
+ * Standalone HTTP-level integration tests for the compression middleware.
+ *
+ * Most assertions live in the supertest block. Because supertest's
+ * underlying superagent auto-decompresses gzip/brotli streams before
+ * calling our `.parse()` hook, we cannot manually decompress what supertest
+ * already decompressed. Instead, those tests assert response headers only.
+ *
+ * The `raw http.get` block is used to fetch the un-decompressed wire
+ * payload, so we can verify round-trip correctness and wire-size reduction.
+ */
+function buildApp(middleware: Middleware, routes: Routes): http.Server {
+  return http.createServer((req, res) => {
+    middleware(req, res, () => {
+      const handler = routes[req.url ?? ''];
+      if (!handler) {
+        res.statusCode = 404;
+        res.end();
+        return;
+      }
+      handler(req, res);
+    });
+  });
+}
+
+function buildTestApp(): http.Server {
+  const routes: Routes = {
+    '/gists': (_req, res) => {
+      res.statusCode = 200;
+      res.setHeader('Content-Type', 'application/json');
+      res.end(
+        JSON.stringify({
+          data: Array.from({ length: 100 }, (_, i) => ({
+            id: `${i}`,
+            content: 'sample content',
+          })),
+          pagination: { count: 100, hasMore: false },
+        }),
+      );
+    },
+    '/gists/large': (_req, res) => {
+      const text = 'the quick brown fox jumps over the lazy dog. ';
+      res.statusCode = 200;
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({ body: text.repeat(500) }));
+    },
+    '/image.png': (_req, res) => {
+      res.statusCode = 200;
+      res.setHeader('Content-Type', 'image/png');
+      res.end(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]));
+    },
+    '/health': (_req, res) => {
+      res.statusCode = 200;
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({ status: 'ok' }));
+    },
+  };
+  return buildApp(compressionMiddleware, routes);
+}
+
+describe('Compression middleware (supertest, header-only)', () => {
+  it('compresses JSON with brotli and chunked transfer when br is preferred', async () => {
+    const res = await request(buildTestApp())
+      .get('/gists/large')
+      .set('Accept-Encoding', 'br, gzip')
+      .expect(200);
+
+    expect(res.headers['content-encoding']).toBe('br');
+    expect(res.headers['vary']).toBe('Accept-Encoding');
+    expect(res.headers['transfer-encoding']).toBe('chunked');
+    expect(res.headers['content-length']).toBeUndefined();
+  });
+
+  it('compresses JSON with gzip when only gzip is advertised', async () => {
+    const res = await request(buildTestApp())
+      .get('/gists/large')
+      .set('Accept-Encoding', 'gzip, deflate')
+      .expect(200);
+
+    expect(res.headers['content-encoding']).toBe('gzip');
+    expect(res.headers['vary']).toBe('Accept-Encoding');
+  });
+
+  it('picks gzip when its q-value beats brotli', async () => {
+    const res = await request(buildTestApp())
+      .get('/gists/large')
+      .set('Accept-Encoding', 'br;q=0.1, gzip;q=0.9')
+      .expect(200);
+
+    expect(res.headers['content-encoding']).toBe('gzip');
+  });
+
+  it('disables a coding via q=0 and picks the remaining one', async () => {
+    const res = await request(buildTestApp())
+      .get('/gists/large')
+      .set('Accept-Encoding', 'gzip;q=0, br')
+      .expect(200);
+
+    expect(res.headers['content-encoding']).toBe('br');
+  });
+
+  it('does NOT compress the /health endpoint even with brotli accepted', async () => {
+    const res = await request(buildTestApp())
+      .get('/health')
+      .set('Accept-Encoding', 'br, gzip')
+      .expect(200);
+    expect(res.headers['content-encoding']).toBeUndefined();
+    expect(res.headers['vary']).toBe('Accept-Encoding');
+  });
+
+  it('does NOT compress image responses', async () => {
+    const res = await request(buildTestApp())
+      .get('/image.png')
+      .set('Accept-Encoding', 'br, gzip')
+      .expect(200);
+    expect(res.headers['content-encoding']).toBeUndefined();
+  });
+  it('still emits Vary: Accept-Encoding when only identity is advertised', async () => {
+    const res = await request(buildTestApp())
+      .get('/gists')
+      .set('Accept-Encoding', 'identity')
+      .expect(200);
+    expect(res.headers['content-encoding']).toBeUndefined();
+    expect(res.headers['vary']).toBe('Accept-Encoding');
+  });
+});
+
+describe('Compression middleware (raw http, round-trip + wire size)', () => {
+  type FetchResult = {
+    headers: http.IncomingHttpHeaders;
+    body: Buffer;
+  };
+
+  function fetchRaw(acceptEncoding: string | null): Promise<FetchResult> {
+    return new Promise((resolve, reject) => {
+      const server = buildTestApp();
+      server.listen(0, () => {
+        const addr = server.address();
+        if (!addr || typeof addr === 'string') {
+          server.close();
+          reject(new Error('Failed to bind test server'));
+          return;
+        }
+        const headers: http.OutgoingHttpHeaders = {};
+        if (acceptEncoding !== null) {
+          headers['Accept-Encoding'] = acceptEncoding;
+        }
+        const req = http.request(
+          {
+            hostname: '127.0.0.1',
+            port: addr.port,
+            path: '/gists/large',
+            method: 'GET',
+            headers,
+          },
+          (res) => {
+            const chunks: Buffer[] = [];
+            res.on('data', (chunk: Buffer) => chunks.push(chunk));
+            res.on('end', () => {
+              server.close();
+              resolve({ headers: res.headers, body: Buffer.concat(chunks) });
+            });
+            res.on('error', reject);
+          },
+        );
+        req.on('error', reject);
+        req.end();
+      });
+    });
+  }
+
+  it('round-trips a brotli body and matches the original payload', async () => {
+    const res = await fetchRaw('br, gzip');
+    expect(res.headers['content-encoding']).toBe('br');
+    const decoded = brotliDecompressSync(res.body).toString('utf8');
+    const json = JSON.parse(decoded) as { body: string };
+    expect(json.body).toContain('the quick brown fox');
+    expect(json.body.length).toBeGreaterThan(5000);
+  });
+
+  it('round-trips a gzip body and matches the original payload', async () => {
+    const res = await fetchRaw('gzip, deflate');
+    expect(res.headers['content-encoding']).toBe('gzip');
+    const decoded = gunzipSync(res.body).toString('utf8');
+    const json = JSON.parse(decoded) as { body: string };
+    expect(json.body).toContain('the quick brown fox');
+  });
+
+  it('reduces wire size for highly compressible payloads', async () => {
+    const uncompressed = await fetchRaw('identity');
+    const compressed = await fetchRaw('gzip, deflate');
+
+    expect(compressed.body.length).toBeLessThan(uncompressed.body.length);
+    expect(compressed.body.length / uncompressed.body.length).toBeLessThan(0.5);
+  });
+
+  it('is graceful when no Accept-Encoding is sent at all', async () => {
+    const res = await fetchRaw(null);
+    expect(res.headers['content-encoding']).toBeUndefined();
+    expect(res.headers['vary']).toBe('Accept-Encoding');
+    expect(res.body.length).toBeGreaterThan(5000);
+  });
+});

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This file is maintained by the `changelog-generator` CI workflow (`infrastructur
 
 ### Features
 
+- perf(backend): add API response compression middleware (#43) — brotli-preferred compression with gzip fallback, RFC 7231 Accept-Encoding / q-value negotiation (including wildcard precedence and explicit `q=0`), ALB/ELB health-check and `HEAD` / `OPTIONS` skips, RFC-compliant body stripping for 204 / 304, zlib Transform streaming that preserves the `res.write` backpressure signal, mid-stream socket teardown on compressor error, buffer reclaim on premature client disconnect, and full unit + HTTP-level e2e coverage
 - add .nvmrc and .env.example files for all workspaces ([1c78cd9](../../commit/1c78cd999379691f3965382ba27aafb927770d1e))
 - add .nvmrc and .env.example files for all workspaces ([ffc655c](../../commit/ffc655c670b1d4fed178c174d0c9a5d452bde565))
 - lazy-load export libraries and implement indexer upsert logic ([1adea97](../../commit/1adea972f2ffca0d0dcf6071cad51c7658272fd1))


### PR DESCRIPTION
Fixes #43

## Description

Adds a NestJS / Express response-compression middleware backed by Node's built-in `zlib` (no `compression` npm package), registered first in `Backend/src/main.ts` so it wraps `res.write` / `res.end` for every downstream handler.

## Acceptance-criteria mapping (from upstream Issue #43)

| Requirement (from #43) | Implementation |
| --- | --- |
| `Content-Encoding: gzip` or `br` header | `shouldCompressContentType` policy + negotiated encoding emitted in `initStream` |
| Response body is compressed (`curl --compressed`) | `test/compression.e2e-spec.ts` raw-http round-trip verifies both brotli **and** gzip decode back to the original payload |
| `/health` not compressed | `DEFAULT_SKIP_PATHS` short-circuit (also `/csrf-token`, `HEAD`, `OPTIONS`) |
| Response-time decrease for large payloads | Wire-size assertion: compressed body is **< 50 %** of uncompressed for repetitive JSON in the e2e suite |
| Accept-Encoding negotiation | RFC 7231 tokenizer handles q-values, wildcards, and explicit `q=0` |
| Prefer brotli over gzip | Tie-break in `negotiateEncoding`; explicit q-value ordering matches RFC 7231 |
| Streaming responses handled correctly | zlib `Transform`, no full-body buffer, boolean backpressure signal preserved |

## Additional guarantees beyond the issue

- **204 / 304 byte-stripping:** even if a controller calls `res.end(payload)` with these statuses, no body bytes reach the wire (RFC 7230 §3.3.1).
- **Compressor-error path:** `res.destroy(err)` instead of `originalEnd()` so a partially-compressed body never reaches the client.
- **Client-disconnect reclaim:** `res.once('close', …)` destroys the zlib `Transform`'s internal buffers so disconnects don't leak memory.
- **Always emits `Vary: Accept-Encoding`** (compressed or not) so CDNs / reverse proxies cache correctly.
- **Strips stale `Content-Length`** when compressing — ALB rejects pre-compression `Content-Length`, and chunked `Transfer-Encoding` is what reaches the wire.

## Verification

- `npx tsc --noEmit` — clean
- `npx eslint <files>` — clean
- `npx prettier --check <files>` — clean
- **22 / 22 unit tests** in `Backend/src/common/middleware/compression.middleware.spec.ts`
- **11 / 11 HTTP-level e2e tests** in `Backend/test/compression.e2e-spec.ts`

Quick local sanity check:

```bash
curl -sS -i \
  -H 'Accept-Encoding: br, gzip' \
  http://localhost:3000/gists/large | head -20
# Expect: Content-Encoding: br, Transfer-Encoding: chunked, Vary: Accept-Encoding
```

## Out-of-scope failures observed in this environment (pre-existing)

`Backend/src/gists/gist.repository.spec.ts` and `Backend/test/app.e2e-spec.ts` fail locally with `TypeError: this.postgres.Pool is not a constructor` because no live Postgres is available; `gists/gist.repository.spec.ts` is gated with `describe.skip` under `process.env.CI`. These are unrelated to this change.

## Files

- add `Backend/src/common/middleware/compression.middleware.ts`
- add `Backend/src/common/middleware/compression.middleware.spec.ts`
- add `Backend/test/compression.e2e-spec.ts`
- modify `Backend/src/main.ts` (register middleware first)
- modify `CHANGELOG.md` (Unreleased / Features)

## Pull-request checklist

- [x] Tests added
- [x] Lint passes
- [x] Type checking passes
- [x] Issue linked (`Fixes #43`)
- [x] CHANGELOG updated
