### PR TITLE
test(frontend): add vitest unit tests for the /api/health route handler

### DIFF
--- a/Frontend/src/app/api/health/route.test.ts
+++ b/Frontend/src/app/api/health/route.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Tests for the GET /api/health liveness probe.
+ *
+ * Follow-up to PR #87 (`docker: add multi-stage frontend Dockerfile with
+ * Next.js standalone output`) so the Next.js App Router endpoint matches
+ * the Docker HEALTHCHECK expectations in `docker/frontend.Dockerfile`.
+ *
+ * The route is exercised by `wget --spider` against
+ * `http://127.0.0.1:${PORT}/api/health`, so we assert only the
+ * duck-typed Web Response shape — no `instanceof` checks against Next.js
+ * internal classes, because vitest's module-resolution surface differs
+ * from the production runtime and `instanceof NextResponse` is not
+ * guaranteed to survive that.
+ */
+import { describe, it, expect } from 'vitest'
+import { GET, dynamic } from './route'
+
+describe('GET /api/health', () => {
+  it('returns status 200', () => {
+    const response = GET()
+    expect(response.status).toBe(200)
+  })
+
+  it('returns application/json content type', () => {
+    const response = GET()
+    expect(response.headers.get('content-type')).toMatch(/application\/json/)
+  })
+
+  it('returns body with status: "ok" and an ISO 8601 timestamp', async () => {
+    const response = GET()
+    const body = await response.json()
+
+    expect(body.status).toBe('ok')
+    expect(typeof body.timestamp).toBe('string')
+    expect(new Date(body.timestamp).toString()).not.toBe('Invalid Date')
+    // Strict ISO 8601 UTC: 2024-05-04T12:34:56.789Z
+    expect(body.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/)
+  })
+})
+
+describe('route module config', () => {
+  it('exports dynamic = "force-dynamic" so Next.js does not pre-render the route', () => {
+    expect(dynamic).toBe('force-dynamic')
+  })
+})


### PR DESCRIPTION
## Summary

Adds vitest unit tests for \`Frontend/src/app/api/health/route.ts\` as a follow-up to PR #87.

The /api/health endpoint is consumed by the Docker HEALTHCHECK directive in \`docker/frontend.Dockerfile\`, so these tests pin down the contract that the liveness probe depends on. They cover:

1. GET() returns status 200
2. GET() returns Content-Type: application/json
3. JSON body has status: \"ok\" plus a strict ISO 8601 UTC timestamp
4. Module-level dynamic = \"force-dynamic\" is exported (so the route is never pre-rendered into static output)

## Validation performed locally

- \`npx vitest run\` -> 9 test files, 48 tests pass (was 44; +4 new)
- \`npx vitest run --coverage\` -> src/app/api/health/route.ts at 100% statements/branches/functions/lines; project overall coverage stays well above the 70% thresholds in vitest.config.ts
- \`npx tsc --noEmit\` -> clean

Refs #87
