### PR TITLE
ci: add Dependabot config with weekly schedule and major/minor groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,140 @@
+version: 2
+
+updates:
+  # ── Root workspace (chart.js, husky, etc.) ───────────────────────────────
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: UTC
+    open-pull-requests-limit: 10
+    rebase-strategy: auto
+    groups:
+      npm-root-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+      npm-root-major:
+        patterns:
+          - "*"
+        update-types:
+          - major
+
+  # ── Frontend (Next.js / React) ───────────────────────────────────────────
+  - package-ecosystem: npm
+    directory: /Frontend
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: UTC
+    open-pull-requests-limit: 10
+    rebase-strategy: auto
+    groups:
+      frontend-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+      frontend-major:
+        patterns:
+          - "*"
+        update-types:
+          - major
+
+  # ── Backend (NestJS) ────────────────────────────────────────────────────
+  - package-ecosystem: npm
+    directory: /Backend
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: UTC
+    open-pull-requests-limit: 10
+    rebase-strategy: auto
+    groups:
+      backend-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+      backend-major:
+        patterns:
+          - "*"
+        update-types:
+          - major
+
+  # ── Analytics (Next.js) ─────────────────────────────────────────────────
+  - package-ecosystem: npm
+    directory: /analytics
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: UTC
+    open-pull-requests-limit: 10
+    rebase-strategy: auto
+    groups:
+      analytics-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+      analytics-major:
+        patterns:
+          - "*"
+        update-types:
+          - major
+
+  # ── Soroban / Rust contracts ─────────────────────────────────────────────
+  - package-ecosystem: cargo
+    directory: /contracts
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: UTC
+    open-pull-requests-limit: 10
+    rebase-strategy: auto
+    groups:
+      cargo-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+      cargo-major:
+        patterns:
+          - "*"
+        update-types:
+          - major
+
+  # ── GitHub Actions ───────────────────────────────────────────────────────
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: UTC
+    open-pull-requests-limit: 10
+    rebase-strategy: auto
+    groups:
+      actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+      actions-major:
+        patterns:
+          - "*"
+        update-types:
+          - major


### PR DESCRIPTION
## Description

Resolves the backlog item from issue #34 by adding a `.github/dependabot.yml` configuration file. Previously, no Dependabot configuration existed in the repository.

Closes #159

## Changes

Added `.github/dependabot.yml` covering all six package ecosystems in the monorepo:

| Ecosystem | Directory |
|-----------|-----------|
| npm (root workspace) | `/` |
| npm (Frontend – Next.js/React) | `/Frontend` |
| npm (Backend – NestJS) | `/Backend` |
| npm (Analytics – Next.js) | `/analytics` |
| cargo (Soroban contracts – Rust) | `/contracts` |
| github-actions | `/` |

**Schedule:** Weekly on Mondays at 06:00 UTC  
**Auto-rebase:** enabled (`rebase-strategy: auto`)  
**Open PR limit:** 10 per ecosystem  
**Dependency groups per ecosystem:**
- `<ecosystem>-minor-patch` — batches all minor and patch bumps into one PR
- `<ecosystem>-major` — isolates major version upgrades for explicit review

## Acceptance Criteria

- [x] `.github/dependabot.yml` present in `.github/`
- [x] Weekly cadence configured for all ecosystems
- [x] Major / minor-patch groups defined per ecosystem
- [x] Auto-rebase enabled for stacked PR compatibility
- First Dependabot PR expected within 14 days of merge

## Checklist

- [x] Documentation updated (config is self-documenting with inline comments)
- [x] Linting passes (YAML is valid)
- [x] Relevant issue linked (`Closes #159`)
- [ ] Tests added or updated — N/A (config-only change)
- [ ] Changelog updated — N/A (infrastructure config)

## Notes for reviewers

- The `rebase-strategy: auto` setting enables Dependabot to auto-rebase its own PRs when the base branch changes, which keeps stacked dependency PRs clean.
- Major version groups are kept separate so they receive explicit human review before merge.
- The `open-pull-requests-limit: 10` per ecosystem prevents PR flood on first run.