### PR TITLE
security(k8s): enforce Pod Security Standards (Restricted) on all namespaces

### DIFF
--- a/infrastructure/k8s/namespaces.yaml
+++ b/infrastructure/k8s/namespaces.yaml
@@ -2,16 +2,41 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: vertexchain-dev
+  labels:
+    # Pod Security Standards — Restricted (https://kubernetes.io/docs/concepts/security/pod-security-standards/)
+    # enforce: blocks non-compliant pods at admission time
+    # audit:   records a violation in the audit log but does not block
+    # warn:    emits a user-facing warning but does not block
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
   name: vertexchain-staging
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
   name: vertexchain-prod
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest
 ---
 apiVersion: v1
 kind: ResourceQuota


### PR DESCRIPTION
## Description

Closes #177

Applies Kubernetes built-in **Pod Security Standards (PSS)** at the `restricted` level to all three application namespaces by adding `pod-security.kubernetes.io/*` labels to `infrastructure/k8s/namespaces.yaml`.

No external admission controller (OPA/Gatekeeper, Kyverno) is required — PSS is implemented natively by the Kubernetes API server since v1.25 (stable).

## Changes

**File modified:** `infrastructure/k8s/namespaces.yaml`

Added the following labels to `vertexchain-dev`, `vertexchain-staging`, and `vertexchain-prod`:

```yaml
pod-security.kubernetes.io/enforce: restricted
pod-security.kubernetes.io/enforce-version: latest
pod-security.kubernetes.io/audit: restricted
pod-security.kubernetes.io/audit-version: latest
pod-security.kubernetes.io/warn: restricted
pod-security.kubernetes.io/warn-version: latest
```

| Mode | Effect |
|------|--------|
| `enforce` | Admission controller **rejects** any pod spec that violates the Restricted policy |
| `audit` | Violations are recorded in the audit log (non-blocking) |
| `warn` | User-facing warning on `kubectl apply` (non-blocking) |

### What the Restricted policy blocks
- Privileged containers
- `hostNetwork` / `hostPID` / `hostIPC`
- `hostPath` volumes
- `allowPrivilegeEscalation: true`
- Containers running as root (`runAsNonRoot` must be `true`)
- Unsafe capabilities (only `NET_BIND_SERVICE` permitted)
- `seccompProfile` must be `RuntimeDefault` or `Localhost`

## Acceptance Criteria

- [x] `vertexchain-dev` labeled `enforce: restricted`
- [x] `vertexchain-staging` labeled `enforce: restricted`
- [x] `vertexchain-prod` labeled `enforce: restricted`
- [x] `audit` + `warn` modes also set (defence-in-depth for observability)
- [x] Applying a pod spec that violates restricted (e.g. `privileged: true`) will be rejected at admission — verified by PSS spec behaviour
- [x] `enforce-version: latest` ensures the policy tracks the cluster's current k8s version automatically

## How to verify after merge

```bash
# Apply the namespace manifest
kubectl apply -f infrastructure/k8s/namespaces.yaml

# Attempt to deploy a privileged pod — should be rejected
kubectl run bad-pod --image=nginx   --overrides='{"spec":{"containers":[{"name":"bad-pod","image":"nginx","securityContext":{"privileged":true}}]}}'   -n vertexchain-dev
# Expected: Error from server (Forbidden): pods ... is forbidden: violates PodSecurity ...
```

## Checklist

- [x] Security improvement applied to all application namespaces
- [x] No external dependencies added (native k8s feature)
- [x] Existing ResourceQuota and NetworkPolicy resources unaffected
- [x] Relevant issue linked (`Closes #177`)
- [ ] Tests added — N/A (infrastructure manifest; verified via `kubectl` command above)
- [ ] Changelog updated — N/A (infrastructure config)