### PR TITLE
docs: add component README entry points

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,5 @@
-# VertexChain: Location-Aware Micro-Messaging on Stellar
+# VertexChain
 
-## Overview
-VertexChain is an open, decentralized platform for anonymous, hyperlocal communication. Users can post short, geotagged messages ("gists") anchored to precise real-world coordinates, enabling local discovery of crowd-sourced tips, alerts, and conversations.
+VertexChain is a location-aware micro-messaging platform built on Stellar. The frontend provides the map-based experience, the NestJS backend serves and indexes nearby gists, Soroban contracts anchor verifiable records on-chain, and the infrastructure layer packages and deploys the system. Together, these components support short geotagged messages with optional Stellar identity, IPFS-backed content, and fast local discovery.
 
-## Architecture
-VertexChain bridges Web2 and Web3 through a hybrid stack:
-- **Frontend / Client Layer**: A geospatial web and mobile interface built using standard Web2 frameworks (React, Mapbox, Leaflet). Users interact with a map-based UI that supports real-time gist retrieval and posting.
-- **Backend / API Layer**: A scalable indexer that handles location queries and data caching, backed by a lightweight RESTful API. Cached data improves performance and supports offline queries.
-- **Blockchain Layer (Stellar Network)**:
-  - Gists are published as tokenized data objects using Stellar's smart contracts (Soroban).
-  - Each gist's metadata hash and location reference are stored immutably on-chain for data integrity, verifiability, and censorship resistance.
-  - Stellar's low-latency consensus and minimal transaction costs allow for near-instant anchoring of posts and edits.
-  - Native Stellar assets can be integrated for staking, moderation incentives, and reputation systems.
-
-## Key Features
-- Anonymous posting with optional cryptographic verification via Stellar addresses
-- Immutable gist records with hash-linked permanence
-- Smart contract enforcement of spatial access rules (visibility radius, cooldown periods, etc.)
-- Off-chain storage bridging for larger data payloads via IPFS or Arweave with on-chain references
-- Secure micropayments and tipping between local contributors using Stellar assets
-
-## Why Stellar
-Stellar provides the ideal foundation for VertexChain's decentralized locality engine due to its:
-- High throughput and low fees — facilitating scalable community interactions
-- Soroban smart contract layer, enabling composable logic for content governance
-- Interoperability with other Web3 ecosystems via Stellar's cross-chain capabilities
+Read the [Backend README](Backend/README.md) / [Frontend README](Frontend/README.md) / [Contracts README](contracts/README.md) / [Infrastructure README](infrastructure/README.md).


### PR DESCRIPTION
## Description

- Replaces the root marketing-heavy README with a one-paragraph project and architecture overview.
- Adds direct entry points for the Backend, Frontend, Contracts, and Infrastructure documentation.
- Preserves every per-component README.

Closes #184

## Checklist

- [x] Documentation updated
- [x] All component links verified locally
- [x] Per-component READMEs retained
- [x] Relevant issue linked

## Security

Documentation-only change; no security-sensitive behavior is affected.

## Notes for reviewers

All four relative README links resolve from the repository root.