### PR TITLE
feat: error boundaries for landing and map pages

### DIFF
--- a/Frontend/src/app/error.test.tsx
+++ b/Frontend/src/app/error.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import GlobalError from "./error";
+
+describe("GlobalError", () => {
+  const mockError = new Error("Test render error");
+  const mockReset = vi.fn();
+
+  it("renders the error heading", () => {
+    render(<GlobalError error={mockError} reset={mockReset} />);
+    expect(
+      screen.getByRole("heading", { name: /something went wrong/i })
+    ).toBeInTheDocument();
+  });
+
+  it("renders the descriptive message", () => {
+    render(<GlobalError error={mockError} reset={mockReset} />);
+    expect(
+      screen.getByText(/an unexpected error occurred/i)
+    ).toBeInTheDocument();
+  });
+
+  it("renders a retry button", () => {
+    render(<GlobalError error={mockError} reset={mockReset} />);
+    expect(
+      screen.getByRole("button", { name: /try again/i })
+    ).toBeInTheDocument();
+  });
+
+  it("calls reset when retry button is clicked", async () => {
+    const user = userEvent.setup();
+    render(<GlobalError error={mockError} reset={mockReset} />);
+    await user.click(screen.getByRole("button", { name: /try again/i }));
+    expect(mockReset).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs the error to the console", () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    render(<GlobalError error={mockError} reset={mockReset} />);
+    expect(consoleSpy).toHaveBeenCalledWith(mockError);
+    consoleSpy.mockRestore();
+  });
+});

--- a/Frontend/src/app/error.tsx
+++ b/Frontend/src/app/error.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useEffect } from "react";
+
+interface ErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function GlobalError({ error, reset }: ErrorProps) {
+  useEffect(() => {
+    // Log the error to an error reporting service in production
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-[#111827] px-4 text-gray-200">
+      <div className="w-full max-w-md rounded-xl border border-gray-700 bg-gray-900 p-8 text-center shadow-lg">
+        {/* Icon */}
+        <div className="mb-4 flex justify-center">
+          <svg
+            aria-hidden="true"
+            className="h-12 w-12 text-[#6366f1]"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={1.5}
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </div>
+
+        <h1 className="mb-2 text-xl font-semibold text-gray-100">
+          Something went wrong
+        </h1>
+        <p className="mb-6 text-sm text-gray-400">
+          An unexpected error occurred. You can try again or refresh the page.
+        </p>
+
+        <button
+          onClick={reset}
+          className="rounded-lg bg-[#6366f1] px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#6366f1]"
+          type="button"
+        >
+          Try again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/Frontend/src/app/map/error.test.tsx
+++ b/Frontend/src/app/map/error.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import MapError from "./error";
+
+describe("MapError", () => {
+  const mockError = new Error("Map render error");
+  const mockReset = vi.fn();
+
+  it("renders the map error heading", () => {
+    render(<MapError error={mockError} reset={mockReset} />);
+    expect(
+      screen.getByRole("heading", { name: /map failed to load/i })
+    ).toBeInTheDocument();
+  });
+
+  it("renders the descriptive message", () => {
+    render(<MapError error={mockError} reset={mockReset} />);
+    expect(
+      screen.getByText(/there was a problem rendering the map/i)
+    ).toBeInTheDocument();
+  });
+
+  it("renders a retry button", () => {
+    render(<MapError error={mockError} reset={mockReset} />);
+    expect(
+      screen.getByRole("button", { name: /try again/i })
+    ).toBeInTheDocument();
+  });
+
+  it("calls reset when retry button is clicked", async () => {
+    const user = userEvent.setup();
+    render(<MapError error={mockError} reset={mockReset} />);
+    await user.click(screen.getByRole("button", { name: /try again/i }));
+    expect(mockReset).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders inside a full-screen container", () => {
+    const { container } = render(<MapError error={mockError} reset={mockReset} />);
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper).toHaveClass("h-screen", "w-screen");
+  });
+
+  it("logs the error to the console", () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    render(<MapError error={mockError} reset={mockReset} />);
+    expect(consoleSpy).toHaveBeenCalledWith(mockError);
+    consoleSpy.mockRestore();
+  });
+});

--- a/Frontend/src/app/map/error.tsx
+++ b/Frontend/src/app/map/error.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useEffect } from "react";
+
+interface ErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function MapError({ error, reset }: ErrorProps) {
+  useEffect(() => {
+    // Log the error to an error reporting service in production
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="flex h-screen w-screen flex-col items-center justify-center bg-[#111827] px-4 text-gray-200">
+      <div className="w-full max-w-md rounded-xl border border-gray-700 bg-gray-900 p-8 text-center shadow-lg">
+        {/* Icon */}
+        <div className="mb-4 flex justify-center">
+          <svg
+            aria-hidden="true"
+            className="h-12 w-12 text-[#6366f1]"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={1.5}
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M9 6.75V15m6-6v8.25m.503 3.498 4.875-2.437c.381-.19.622-.58.622-1.006V4.82c0-.836-.88-1.38-1.628-1.006l-3.869 1.934c-.317.159-.69.159-1.006 0L9.503 3.252a1.125 1.125 0 0 0-1.006 0L3.622 5.689C3.24 5.88 3 6.27 3 6.695V19.18c0 .836.88 1.38 1.628 1.006l3.869-1.934c.317-.159.69-.159 1.006 0l4.994 2.497c.317.158.69.158 1.006 0Z"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </div>
+
+        <h1 className="mb-2 text-xl font-semibold text-gray-100">
+          Map failed to load
+        </h1>
+        <p className="mb-6 text-sm text-gray-400">
+          There was a problem rendering the map. You can try again or refresh
+          the page.
+        </p>
+
+        <button
+          onClick={reset}
+          className="rounded-lg bg-[#6366f1] px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#6366f1]"
+          type="button"
+        >
+          Try again
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Add Next.js App Router `error.tsx` files for the root and `/map` routes so any render-time exception shows a styled fallback with a "Try again" retry button instead of crashing the page.

## Changes

| File | Purpose |
|------|---------|
| `Frontend/src/app/error.tsx` | Global error boundary (`GlobalError`) – catches errors in any route |
| `Frontend/src/app/map/error.tsx` | Map-specific error boundary (`MapError`) – scoped fallback for the map page |
| `Frontend/src/app/error.test.tsx` | 5 colocated Vitest tests for GlobalError |
| `Frontend/src/app/map/error.test.tsx` | 6 colocated Vitest tests for MapError |

## Acceptance criteria

- [x] Throw a render-error in a test component → fallback renders (verified via Vitest with a mock error prop)
- [x] Fallback includes a styled "Try again" retry button that calls Next.js `reset()`
- [x] Dark theme (`bg-[#111827]`) and indigo accent (`#6366f1`) match project conventions
- [x] 11/11 tests pass (`vitest run`)

## Testing

```
cd Frontend && npm ci && ./node_modules/.bin/vitest run src/app/error.test.tsx src/app/map/error.test.tsx
# Test Files  2 passed (2)
# Tests       11 passed (11)
```

Closes #143