### PR TITLE
chore: add hadolint CI job for Dockerfiles

### DIFF
--- a/.github/workflows/container-lint.yml
+++ b/.github/workflows/container-lint.yml
@@ -1,0 +1,36 @@
+name: Container Lint
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'docker/**'
+      - '.hadolint.yaml'
+      - '.github/workflows/container-lint.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'docker/**'
+      - '.hadolint.yaml'
+      - '.github/workflows/container-lint.yml'
+
+concurrency:
+  group: container-lint-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  hadolint:
+    name: Hadolint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run Hadolint
+        run: |
+          # Fetch the latest hadolint release if not present, but it is typically in ubuntu-latest
+          # To be safe and deterministic, we can pull the docker image and run it.
+          docker run --rm -i -v "${PWD}:/work" -w /work hadolint/hadolint:latest hadolint docker/backend.Dockerfile docker/frontend.Dockerfile

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,3 @@
+ignored:
+  - DL3018 # Pin versions in apk add
+failure-threshold: warning


### PR DESCRIPTION
This pr closes #160

## Description
This PR resolves the issue where the `docker/*.Dockerfile` files were not linted. A linted Dockerfile builds faster, is smaller, and limits security vulnerabilities.

## Changes Included
- Added `.github/workflows/container-lint.yml` to run the `hadolint` CI check automatically on both `docker/backend.Dockerfile` and `docker/frontend.Dockerfile` whenever changes are pushed or a pull request is raised.
- Configured `.hadolint.yaml` to ensure the lint step effectively enforces rules. Currently, it triggers failure only on a warnings threshold and correctly suppresses known benign `apk add` version-pinning rules (DL3018) that would unnecessarily block builds.

## How to Verify
When you open this PR, you should see the new `Container Lint` job executing in GitHub Actions. It should succeed (if no other issues are present) and automatically check for common traps such as `apt-get` issues or missing configurations.