### PR TITLE
feat(frontend): support prefers-reduced-motion in landing page compon…

### DIFF
--- a/Frontend/src/components/landing/CTA.tsx
+++ b/Frontend/src/components/landing/CTA.tsx
@@ -5,17 +5,27 @@ import { ArrowRight } from 'lucide-react';
 import { useGSAP } from '@gsap/react';
 import gsap from 'gsap';
 import { ScrollTrigger } from 'gsap/ScrollTrigger';
-import { useRef } from 'react';
+import { useRef, useState, useEffect } from 'react';
 import { GridPattern } from '@/components/ui/grid-pattern';
+import { useReducedMotion } from '@/hooks/useReducedMotion';
 import { cn } from '@/lib/utils';
 
 gsap.registerPlugin(ScrollTrigger);
 
 export default function CTA() {
   const containerRef = useRef(null);
+  const reducedMotion = useReducedMotion();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   useGSAP(
     () => {
+      if (!mounted) return;
+      if (reducedMotion) return;
+
       gsap.from('.cta-content', {
         scrollTrigger: {
           trigger: containerRef.current,
@@ -29,7 +39,7 @@ export default function CTA() {
         ease: 'power3.out',
       });
     },
-    { scope: containerRef }
+    { scope: containerRef, dependencies: [mounted, reducedMotion] }
   );
 
   return (
@@ -52,17 +62,50 @@ export default function CTA() {
         <div className="glow-layer"></div>
 
         <div className="relative z-10 p-8 md:p-12 rounded-3xl bg-black/40 backdrop-blur-xl border border-white/10">
-          <h2 className="cta-content text-3xl font-bold text-white md:text-4xl">
+          <h2
+            className="cta-content text-3xl font-bold text-white md:text-4xl"
+            style={
+              reducedMotion
+                ? {
+                    opacity: mounted ? 1 : 0,
+                    transition: 'opacity 0.8s ease-out',
+                    transitionDelay: '0s',
+                  }
+                : undefined
+            }
+          >
             Ready to See What&apos;s{' '}
             <span className="text-purple-500">Happening</span>?
           </h2>
 
-          <p className="cta-content max-w-xl mx-auto mt-4 text-white/70">
+          <p
+            className="cta-content max-w-xl mx-auto mt-4 text-white/70"
+            style={
+              reducedMotion
+                ? {
+                    opacity: mounted ? 1 : 0,
+                    transition: 'opacity 0.8s ease-out',
+                    transitionDelay: '0.2s',
+                  }
+                : undefined
+            }
+          >
             From the bustling streets of Lagos to the quiet corners of your
             neighborhood, discover and share what&apos;s happening right now.
             Your community is waiting.
           </p>
-          <div className="cta-content mt-8">
+          <div
+            className="cta-content mt-8"
+            style={
+              reducedMotion
+                ? {
+                    opacity: mounted ? 1 : 0,
+                    transition: 'opacity 0.8s ease-out',
+                    transitionDelay: '0.4s',
+                  }
+                : undefined
+            }
+          >
             <Link
               href="/map"
               className="inline-flex items-center justify-center px-8 py-3 text-lg font-semibold text-black transition-all duration-300 bg-purple-950 rounded-lg hover:bg-purple-900 hover:scale-105"

--- a/Frontend/src/components/landing/Features.test.tsx
+++ b/Frontend/src/components/landing/Features.test.tsx
@@ -101,7 +101,7 @@ describe('Features', () => {
       });
     } else {
       // @ts-expect-error - deleting matchMedia if it wasn't originally defined
-      delete (window as any).matchMedia;
+      delete (window as { matchMedia?: unknown }).matchMedia;
     }
   })
 })

--- a/Frontend/src/components/landing/Features.test.tsx
+++ b/Frontend/src/components/landing/Features.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import { describe, it, expect, vi, beforeAll } from 'vitest'
 import { Features } from './Features'
+import gsap from 'gsap'
 
 vi.mock('next/image', () => ({
   default: ({ alt }: { alt: string }) => <img alt={alt} />,
@@ -66,5 +67,41 @@ describe('Features', () => {
     window.dispatchEvent(new Event('resize'))
     render(<Features />)
     expect(screen.getByText('The Hyperlocal Information Hub')).toBeInTheDocument()
+  })
+
+  it('does not trigger GSAP animations when prefers-reduced-motion is enabled', () => {
+    const originalMatchMedia = window.matchMedia;
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      configurable: true,
+      value: vi.fn().mockImplementation((query) => ({
+        matches: query === '(prefers-reduced-motion: reduce)',
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+
+    const mockFromTo = vi.mocked(gsap.fromTo);
+    mockFromTo.mockClear();
+
+    render(<Features />);
+
+    expect(mockFromTo).not.toHaveBeenCalled();
+
+    if (originalMatchMedia) {
+      Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        configurable: true,
+        value: originalMatchMedia,
+      });
+    } else {
+      // @ts-expect-error - deleting matchMedia if it wasn't originally defined
+      delete (window as any).matchMedia;
+    }
   })
 })

--- a/Frontend/src/components/landing/Features.tsx
+++ b/Frontend/src/components/landing/Features.tsx
@@ -5,6 +5,7 @@ import { Badge } from '../ui/badge';
 import { AnimatedBeam } from "../magicui/animated-beam";
 import { Circle } from './Circle';
 import gsap from 'gsap';
+import { useReducedMotion } from '@/hooks/useReducedMotion';
 import {
   Lightbulb, MapPinIcon, UsersIcon, Siren,
   Globe, ShieldCheck, MessageSquare, TimerIcon, Zap
@@ -25,6 +26,12 @@ const useIsMobile = () => {
 export const Features: React.FC = () => {
   const featureRefs = useRef<HTMLDivElement[]>([]);
   const isMobile = useIsMobile();
+  const reducedMotion = useReducedMotion();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   // Responsive center points
   const centerX = isMobile ? 160 : 225;
@@ -43,6 +50,9 @@ export const Features: React.FC = () => {
   ];
 
   useEffect(() => {
+    if (!mounted) return;
+    if (reducedMotion) return;
+
     featureRefs.current.forEach((el, index) => {
       gsap.fromTo(
         el,
@@ -56,7 +66,7 @@ export const Features: React.FC = () => {
         }
       );
     });
-  }, []);
+  }, [mounted, reducedMotion]);
 
   const features = [
     {
@@ -134,6 +144,15 @@ export const Features: React.FC = () => {
                   if (el) featureRefs.current[index] = el;
                 }}
                 className="p-4 sm:p-6 bg-neutral-950 backdrop-blur-md rounded-lg shadow-lg border border-gray-700/50"
+                style={
+                  reducedMotion
+                    ? {
+                        opacity: mounted ? 1 : 0,
+                        transition: 'opacity 0.8s ease-out',
+                        transitionDelay: `${index * 0.2}s`,
+                      }
+                    : undefined
+                }
               >
                 <div className="flex items-start space-x-4">
                   <div className="flex-shrink-0 w-10 h-10 rounded-full bg-gray-800 flex items-center justify-center">

--- a/Frontend/src/hooks/useReducedMotion.ts
+++ b/Frontend/src/hooks/useReducedMotion.ts
@@ -1,0 +1,35 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+/**
+ * Custom hook to detect user preference for reduced motion.
+ * Returns true if the user prefers reduced motion, false otherwise.
+ */
+export function useReducedMotion(): boolean {
+  const [reducedMotion, setReducedMotion] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    setReducedMotion(mediaQuery.matches);
+
+    const listener = (event: MediaQueryListEvent) => {
+      setReducedMotion(event.matches);
+    };
+
+    if (mediaQuery.addEventListener) {
+      mediaQuery.addEventListener('change', listener);
+      return () => mediaQuery.removeEventListener('change', listener);
+    } else if (mediaQuery.addListener) {
+      // Fallback for older browsers and JSDOM environments
+      mediaQuery.addListener(listener);
+      return () => mediaQuery.removeListener(listener);
+    }
+  }, []);
+
+  return reducedMotion;
+}


### PR DESCRIPTION
Closes #137 

Description
This PR addresses accessibility issues by introducing a custom useReducedMotion React hook to check and listen to the (prefers-reduced-motion: reduce) media query.

When reduced motion is preferred by the user's OS, heavy GSAP timelines and ScrollTrigger effects in the Features and CTA components are bypassed. Instead, these components gracefully fade in using lightweight, pure CSS transitions.

Key Changes
useReducedMotion Hook (
useReducedMotion.ts
): A custom hook that queries window.matchMedia('(prefers-reduced-motion: reduce)') and dynamically listens for changes.
Features Component (
Features.tsx
): Consumes the hook and disables GSAP fromTo timelines when reduced motion is preferred. Elements fade in via standard CSS styling.
CTA Component (
CTA.tsx
): Consumes the hook, disables the ScrollTrigger GSAP animation, and utilizes staggered CSS transitions.
Mount Guards: Added a mounted state check to both components. This ensures that media query settings are resolved before animations are evaluated, avoiding layout shifts and preventing GSAP triggers on first render.
Automated Tests (
Features.test.tsx
): Added a Vitest test that mocks the media query and asserts gsap.fromTo is not invoked when reduce is true.