### PR TITLE
fix(map): improve Leaflet popup contrast in dark mode

### DIFF
--- a/Frontend/src/components/map/Map.tsx
+++ b/Frontend/src/components/map/Map.tsx
@@ -2,6 +2,7 @@
 
 import { MapContainer, TileLayer, Marker, Popup, useMap } from 'react-leaflet';
 import 'leaflet/dist/leaflet.css';
+import '@/styles/leaflet-dark.css';
 import { icon } from 'leaflet';
 import { useState, useEffect } from 'react';
 import { Plus } from 'lucide-react';

--- a/Frontend/src/styles/leaflet-dark.css
+++ b/Frontend/src/styles/leaflet-dark.css
@@ -1,0 +1,39 @@
+@media (prefers-color-scheme: dark) {
+  .leaflet-popup-content-wrapper {
+    background: #1f2937;
+    color: #f9fafb;
+    border: 1px solid #374151;
+    box-shadow: 0 3px 14px rgba(0, 0, 0, 0.5);
+  }
+
+  .leaflet-popup-content {
+    color: inherit;
+  }
+
+  .leaflet-popup-content a {
+    color: #93c5fd;
+  }
+
+  .leaflet-popup-content a:hover {
+    color: #bfdbfe;
+  }
+
+  .leaflet-popup-tip {
+    background: #1f2937;
+  }
+
+  .leaflet-container a.leaflet-popup-close-button {
+    color: #f9fafb;
+  }
+
+  .leaflet-container a.leaflet-popup-close-button:hover {
+    color: #ffffff;
+    background: #111827;
+  }
+
+  .leaflet-container a.leaflet-popup-close-button:focus-visible {
+    outline: 2px solid #6366f1;
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
+}


### PR DESCRIPTION
# Pull Request

## Description

- Added a dedicated dark-mode stylesheet for Leaflet popups.
- Improved popup background, text, popup tip, and close button contrast using `prefers-color-scheme: dark`.
- Imported the stylesheet in `src/components/map/Map.tsx` after the default Leaflet stylesheet.
- Related issue: Closes #142

## Checklist

- [ ] Tests added or updated
- [ ] Documentation updated (README, docs, comments)
- [x] Linting passes
- [x] Type checking passes (if applicable)
- [x] Relevant issue linked
- [ ] Changelog updated (if applicable)

## Security

N/A. This change only affects the visual styling of Leaflet popups in dark mode and does not modify authentication, secrets, or data handling.

## Notes for reviewers

### What to verify

- Enable dark mode (`prefers-color-scheme: dark`).
- Navigate to `/map`.
- Open a Leaflet popup by clicking a marker.
- Verify the popup background, text, popup tip, and close button have sufficient contrast.
- Confirm the popup appearance remains unchanged in light mode.

### Validation

- ✅ `npm run lint`
- ✅ `npm run test` (44/44 passing)
- ✅ `npm run build`