### PR TITLE
Feat: prometheus rules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: stable
           targets: wasm32-unknown-unknown
           components: rustfmt, clippy
 

--- a/contracts/batch-wallet/src/events.rs
+++ b/contracts/batch-wallet/src/events.rs
@@ -1,0 +1,31 @@
+use soroban_sdk::{symbol_short, Address, Env};
+
+pub struct BatchWalletEvents;
+
+impl BatchWalletEvents {
+    pub fn batch_started(env: &Env, batch_id: u64, request_count: u32) {
+        let topics = (symbol_short!("batch"), symbol_short!("started"), batch_id);
+        env.events().publish(topics, request_count);
+    }
+
+    pub fn wallet_created(env: &Env, wallet_id: u64, owner: &Address) {
+        let topics = (symbol_short!("wallet"), symbol_short!("created"), wallet_id);
+        env.events().publish(topics, owner.clone());
+    }
+
+    pub fn wallet_duplicate(env: &Env, owner: &Address) {
+        let topics = (symbol_short!("wallet"), symbol_short!("duplicate"));
+        env.events().publish(topics, owner.clone());
+    }
+
+    pub fn batch_completed(env: &Env, batch_id: u64, successful: u32, failed: u32) {
+        let topics = (symbol_short!("batch"), symbol_short!("completed"), batch_id);
+        env.events().publish(topics, (successful, failed));
+    }
+
+    pub fn wallet_recovered(env: &Env, old_owner: &Address, new_owner: &Address) {
+        let topics = (symbol_short!("wallet"), symbol_short!("recovered"));
+        env.events()
+            .publish(topics, (old_owner.clone(), new_owner.clone()));
+    }
+}

--- a/contracts/batch-wallet/src/lib.rs
+++ b/contracts/batch-wallet/src/lib.rs
@@ -1,7 +1,6 @@
 #![no_std]
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, panic_with_error, Address,
-    Env, Vec,
+    contract, contracterror, contractimpl, contracttype, panic_with_error, Address, Env, Vec,
 };
 
 #[derive(Clone)]

--- a/contracts/batch-wallet/src/lib.rs
+++ b/contracts/batch-wallet/src/lib.rs
@@ -82,35 +82,8 @@ pub enum BatchWalletError {
     Overflow = 9,
 }
 
-pub struct BatchWalletEvents;
-
-impl BatchWalletEvents {
-    pub fn batch_started(env: &Env, batch_id: u64, request_count: u32) {
-        let topics = (symbol_short!("batch"), symbol_short!("started"), batch_id);
-        env.events().publish(topics, request_count);
-    }
-
-    pub fn wallet_created(env: &Env, wallet_id: u64, owner: &Address) {
-        let topics = (symbol_short!("wallet"), symbol_short!("created"), wallet_id);
-        env.events().publish(topics, owner.clone());
-    }
-
-    pub fn wallet_duplicate(env: &Env, owner: &Address) {
-        let topics = (symbol_short!("wallet"), symbol_short!("duplicate"));
-        env.events().publish(topics, owner.clone());
-    }
-
-    pub fn batch_completed(env: &Env, batch_id: u64, successful: u32, failed: u32) {
-        let topics = (symbol_short!("batch"), symbol_short!("completed"), batch_id);
-        env.events().publish(topics, (successful, failed));
-    }
-
-    pub fn wallet_recovered(env: &Env, old_owner: &Address, new_owner: &Address) {
-        let topics = (symbol_short!("wallet"), symbol_short!("recovered"));
-        env.events()
-            .publish(topics, (old_owner.clone(), new_owner.clone()));
-    }
-}
+mod events;
+pub use events::BatchWalletEvents;
 
 pub fn initialize(env: &Env, admin: Address) {
     if env.storage().instance().has(&DataKey::Admin) {

--- a/contracts/batch-wallet/src/lib.rs
+++ b/contracts/batch-wallet/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, panic_with_error, symbol_short, Address,
+    contract, contracterror, contractimpl, contracttype, panic_with_error, Address,
     Env, Vec,
 };
 

--- a/contracts/governance/src/events.rs
+++ b/contracts/governance/src/events.rs
@@ -1,0 +1,56 @@
+use soroban_sdk::{symbol_short, Address, Env, String};
+
+pub struct GovernanceEvents;
+
+impl GovernanceEvents {
+    pub fn admin_updated(env: &Env, previous_admin: &Address, new_admin: &Address) {
+        let topics = (symbol_short!("gov"), symbol_short!("admin"));
+        env.events().publish(
+            topics,
+            (
+                previous_admin.clone(),
+                new_admin.clone(),
+                env.ledger().timestamp(),
+            ),
+        );
+    }
+
+    pub fn proposal_created(
+        env: &Env,
+        id: u32,
+        proposer: &Address,
+        config_key: &String,
+        config_value: &String,
+    ) {
+        let topics = (symbol_short!("gov"), symbol_short!("created"));
+        env.events().publish(
+            topics,
+            (
+                id,
+                proposer.clone(),
+                config_key.clone(),
+                config_value.clone(),
+                env.ledger().timestamp(),
+            ),
+        );
+    }
+
+    pub fn voted(env: &Env, id: u32, voter: &Address) {
+        let topics = (symbol_short!("gov"), symbol_short!("voted"));
+        env.events()
+            .publish(topics, (id, voter.clone(), env.ledger().timestamp()));
+    }
+
+    pub fn proposal_executed(env: &Env, id: u32, config_key: &String, config_value: &String) {
+        let topics = (symbol_short!("gov"), symbol_short!("executed"));
+        env.events().publish(
+            topics,
+            (
+                id,
+                config_key.clone(),
+                config_value.clone(),
+                env.ledger().timestamp(),
+            ),
+        );
+    }
+}

--- a/contracts/governance/src/lib.rs
+++ b/contracts/governance/src/lib.rs
@@ -1,7 +1,6 @@
 #![no_std]
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, panic_with_error, Address,
-    Env, String,
+    contract, contracterror, contractimpl, contracttype, panic_with_error, Address, Env, String,
 };
 
 #[derive(Clone)]

--- a/contracts/governance/src/lib.rs
+++ b/contracts/governance/src/lib.rs
@@ -43,60 +43,8 @@ pub enum GovernanceError {
     InvalidInput = 10,
 }
 
-pub struct GovernanceEvents;
-
-impl GovernanceEvents {
-    pub fn admin_updated(env: &Env, previous_admin: &Address, new_admin: &Address) {
-        let topics = (symbol_short!("gov"), symbol_short!("admin"));
-        env.events().publish(
-            topics,
-            (
-                previous_admin.clone(),
-                new_admin.clone(),
-                env.ledger().timestamp(),
-            ),
-        );
-    }
-
-    pub fn proposal_created(
-        env: &Env,
-        id: u32,
-        proposer: &Address,
-        config_key: &String,
-        config_value: &String,
-    ) {
-        let topics = (symbol_short!("gov"), symbol_short!("created"));
-        env.events().publish(
-            topics,
-            (
-                id,
-                proposer.clone(),
-                config_key.clone(),
-                config_value.clone(),
-                env.ledger().timestamp(),
-            ),
-        );
-    }
-
-    pub fn voted(env: &Env, id: u32, voter: &Address) {
-        let topics = (symbol_short!("gov"), symbol_short!("voted"));
-        env.events()
-            .publish(topics, (id, voter.clone(), env.ledger().timestamp()));
-    }
-
-    pub fn proposal_executed(env: &Env, id: u32, config_key: &String, config_value: &String) {
-        let topics = (symbol_short!("gov"), symbol_short!("executed"));
-        env.events().publish(
-            topics,
-            (
-                id,
-                config_key.clone(),
-                config_value.clone(),
-                env.ledger().timestamp(),
-            ),
-        );
-    }
-}
+mod events;
+pub use events::GovernanceEvents;
 
 pub fn initialize_governance(env: &Env, admin: Address, required_approvals: u32) {
     if env.storage().instance().has(&GovernanceDataKey::Admin) {

--- a/contracts/governance/src/lib.rs
+++ b/contracts/governance/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, panic_with_error, symbol_short, Address,
+    contract, contracterror, contractimpl, contracttype, panic_with_error, Address,
     Env, String,
 };
 

--- a/contracts/multisig/src/events.rs
+++ b/contracts/multisig/src/events.rs
@@ -1,0 +1,40 @@
+use crate::PendingTx;
+use soroban_sdk::{symbol_short, Address, Env};
+
+pub struct MultisigEvents;
+
+impl MultisigEvents {
+    pub fn pending_created(env: &Env, tx: &PendingTx) {
+        let topics = (symbol_short!("tx"), symbol_short!("pending"), tx.id);
+        env.events().publish(
+            topics,
+            (tx.from.clone(), tx.to.clone(), tx.amount, tx.asset.clone()),
+        );
+    }
+
+    pub fn approval_recorded(
+        env: &Env,
+        tx_id: u64,
+        signer: &Address,
+        approvals_count: u32,
+        threshold: u32,
+    ) {
+        let topics = (symbol_short!("approve"), symbol_short!("record"), tx_id);
+        env.events()
+            .publish(topics, (signer.clone(), approvals_count, threshold));
+    }
+
+    pub fn transaction_executed(env: &Env, tx: &PendingTx, executor: &Address) {
+        let topics = (symbol_short!("tx"), symbol_short!("executed"), tx.id);
+        env.events().publish(
+            topics,
+            (
+                executor.clone(),
+                tx.from.clone(),
+                tx.to.clone(),
+                tx.amount,
+                tx.asset.clone(),
+            ),
+        );
+    }
+}

--- a/contracts/multisig/src/lib.rs
+++ b/contracts/multisig/src/lib.rs
@@ -50,43 +50,8 @@ pub enum MultiSigError {
     Overflow = 13,
 }
 
-pub struct MultisigEvents;
-
-impl MultisigEvents {
-    pub fn pending_created(env: &Env, tx: &PendingTx) {
-        let topics = (symbol_short!("tx"), symbol_short!("pending"), tx.id);
-        env.events().publish(
-            topics,
-            (tx.from.clone(), tx.to.clone(), tx.amount, tx.asset.clone()),
-        );
-    }
-
-    pub fn approval_recorded(
-        env: &Env,
-        tx_id: u64,
-        signer: &Address,
-        approvals_count: u32,
-        threshold: u32,
-    ) {
-        let topics = (symbol_short!("approve"), symbol_short!("record"), tx_id);
-        env.events()
-            .publish(topics, (signer.clone(), approvals_count, threshold));
-    }
-
-    pub fn transaction_executed(env: &Env, tx: &PendingTx, executor: &Address) {
-        let topics = (symbol_short!("tx"), symbol_short!("executed"), tx.id);
-        env.events().publish(
-            topics,
-            (
-                executor.clone(),
-                tx.from.clone(),
-                tx.to.clone(),
-                tx.amount,
-                tx.asset.clone(),
-            ),
-        );
-    }
-}
+mod events;
+pub use events::MultisigEvents;
 
 pub fn initialize_state(env: &Env, admin: Address) {
     if env.storage().instance().has(&DataKey::Admin) {

--- a/contracts/multisig/src/lib.rs
+++ b/contracts/multisig/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, panic_with_error, Address,
-    Env, Symbol, Vec,
+    contract, contracterror, contractimpl, contracttype, panic_with_error, Address, Env, Symbol,
+    Vec,
 };
 
 #[derive(Clone)]

--- a/contracts/multisig/src/lib.rs
+++ b/contracts/multisig/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, panic_with_error, symbol_short, Address,
+    contract, contracterror, contractimpl, contracttype, panic_with_error, Address,
     Env, Symbol, Vec,
 };
 

--- a/infrastructure/ci/contract-audit.yml
+++ b/infrastructure/ci/contract-audit.yml
@@ -21,6 +21,8 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
 
       - name: Install cargo-audit
         run: cargo install cargo-audit --locked

--- a/infrastructure/ci/contract-deployment.yml
+++ b/infrastructure/ci/contract-deployment.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: stable
           targets: wasm32-unknown-unknown
 
       - name: Cache Rust dependencies
@@ -58,6 +59,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: stable
           targets: wasm32-unknown-unknown
 
       - name: Install Stellar CLI

--- a/infrastructure/k8s/edge-ratelimit/README.md
+++ b/infrastructure/k8s/edge-ratelimit/README.md
@@ -1,0 +1,38 @@
+# Edge Rate Limiting Gateway Configuration
+
+This directory contains the Kubernetes configurations to enable edge rate limiting for the VertexChain application, specifically targeting the `POST /gists` endpoint.
+
+## Architecture
+
+To protect the backend from thundering herd problems and coordinated abuse (such as concurrent bursts of requests), we use a layered rate limiting strategy at the edge (Envoy Ingress Gateway):
+
+1. **Local Rate Limit (`envoy.filters.http.local_ratelimit`)**:
+   - Enforced directly in each Envoy proxy pod without external network hops.
+   - Designed to handle sudden concurrent bursts instantly.
+   - Configured to limit `POST /gists` to a burst of 10 requests with a fill rate of 5 tokens per second.
+
+2. **Global Rate Limit (`envoy.filters.http.ratelimit`)**:
+   - Enforced cluster-wide using a centralized Redis store and a gRPC Rate Limit service.
+   - Ensures coordinated limits across all Envoy proxy replicas.
+   - Passes method and path headers as descriptors (`path: /gists`, `method: POST`).
+
+## Components
+
+- **`global-rate-limit-crd.yaml`**: The CustomResourceDefinition (`GlobalRateLimit`) outlining the schema for gateway rate limit configurations.
+- **`global-rate-limit-cr.yaml`**: The Custom Resource definition setting the policies specifically for `POST /gists`.
+- **`envoy-filter.yaml`**: The EnvoyFilter resource configuring the Envoy proxy to execute local rate limiting and generate global rate-limit descriptors.
+
+## Deployment
+
+Apply the configurations to your Kubernetes cluster:
+
+```bash
+# 1. Register the GlobalRateLimit CRD
+kubectl apply -f global-rate-limit-crd.yaml
+
+# 2. Deploy the GlobalRateLimit rule
+kubectl apply -f global-rate-limit-cr.yaml
+
+# 3. Apply the EnvoyFilter to the gateway
+kubectl apply -f envoy-filter.yaml
+```

--- a/infrastructure/k8s/edge-ratelimit/envoy-filter.yaml
+++ b/infrastructure/k8s/edge-ratelimit/envoy-filter.yaml
@@ -1,0 +1,98 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: edge-rate-limit-gists
+  namespace: istio-system
+spec:
+  workloadSelector:
+    labels:
+      istio: ingressgateway
+  configPatches:
+    # 1. Insert Local Rate Limit Filter before the router
+    - applyTo: HTTP_FILTER
+      match:
+        context: GATEWAY
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.filters.network.http_connection_manager"
+              subFilter:
+                name: "envoy.filters.http.router"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: envoy.filters.http.local_ratelimit
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+            stat_prefix: edge_local_rate_limiter
+            token_bucket:
+              max_tokens: 1000
+              tokens_per_fill: 1000
+              fill_interval: 1s
+            filter_enabled:
+              runtime_key: local_rate_limit_enabled
+              default_value:
+                numerator: 100
+                denominator: HUNDRED
+            filter_enforced:
+              runtime_key: local_rate_limit_enforced
+              default_value:
+                numerator: 100
+                denominator: HUNDRED
+            # Descriptors to apply rate limiting locally per-gateway-pod to protect backend from thundering herd
+            descriptors:
+              - entries:
+                  - key: "path"
+                    value: "/gists"
+                  - key: "method"
+                    value: "POST"
+                token_bucket:
+                  max_tokens: 10
+                  tokens_per_fill: 5
+                  fill_interval: 1s
+
+    # 2. Insert Global Rate Limit Filter (communicates with external Redis rate limit service)
+    - applyTo: HTTP_FILTER
+      match:
+        context: GATEWAY
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.filters.network.http_connection_manager"
+              subFilter:
+                name: "envoy.filters.http.router"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: envoy.filters.http.ratelimit
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimit
+            domain: edge-gateway-limits
+            stage: 0
+            rate_limit_service:
+              grpc_service:
+                envoy_grpc:
+                  cluster_name: outbound|8081||ratelimit.istio-system.svc.cluster.local
+              transport_api_version: V3
+
+    # 3. Configure Route Action to populate descriptors for Global Rate Limiter matching POST /gists
+    - applyTo: HTTP_ROUTE
+      match:
+        context: GATEWAY
+        routeConfiguration:
+          vhost:
+            name: "*:80"
+            route:
+              action: ANY
+      patch:
+        operation: MERGE
+        value:
+          route:
+            rate_limits:
+              - actions:
+                  - request_headers:
+                      header_name: ":path"
+                      descriptor_key: "path"
+                  - request_headers:
+                      header_name: ":method"
+                      descriptor_key: "method"

--- a/infrastructure/k8s/edge-ratelimit/global-rate-limit-cr.yaml
+++ b/infrastructure/k8s/edge-ratelimit/global-rate-limit-cr.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.vertexchain.io/v1alpha1
+kind: GlobalRateLimit
+metadata:
+  name: gists-edge-limit
+  namespace: vertexchain
+spec:
+  selector:
+    gateway: vertexchain-gateway
+  rules:
+    - path: "/gists"
+      method: "POST"
+      localLimit:
+        burst: 10
+        rate: 5
+        unit: "second"
+      globalLimit:
+        key: "post_gists"
+        requestsPerUnit: 100
+        unit: "minute"

--- a/infrastructure/k8s/edge-ratelimit/global-rate-limit-crd.yaml
+++ b/infrastructure/k8s/edge-ratelimit/global-rate-limit-crd.yaml
@@ -1,0 +1,71 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: globalratelimits.networking.vertexchain.io
+spec:
+  group: networking.vertexchain.io
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required:
+                - rules
+              properties:
+                selector:
+                  type: object
+                  properties:
+                    gateway:
+                      type: string
+                rules:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - path
+                      - method
+                    properties:
+                      path:
+                        type: string
+                      method:
+                        type: string
+                      localLimit:
+                        type: object
+                        required:
+                          - burst
+                          - rate
+                          - unit
+                        properties:
+                          burst:
+                            type: integer
+                          rate:
+                            type: integer
+                          unit:
+                            type: string
+                            enum: [second, minute, hour]
+                      globalLimit:
+                        type: object
+                        required:
+                          - key
+                          - requestsPerUnit
+                          - unit
+                        properties:
+                          key:
+                            type: string
+                          requestsPerUnit:
+                            type: integer
+                          unit:
+                            type: string
+                            enum: [second, minute, hour, day]
+  names:
+    kind: GlobalRateLimit
+    plural: globalratelimits
+    singular: globalratelimit
+    shortNames:
+      - grl
+  scope: Namespaced

--- a/infrastructure/k8s/policy/constraints/disallow-latest-tag-constraint.yaml
+++ b/infrastructure/k8s/policy/constraints/disallow-latest-tag-constraint.yaml
@@ -1,0 +1,9 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sDisallowLatestTag
+metadata:
+  name: disallow-latest-tag
+spec:
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]

--- a/infrastructure/k8s/policy/constraints/no-privileged-constraint.yaml
+++ b/infrastructure/k8s/policy/constraints/no-privileged-constraint.yaml
@@ -1,0 +1,9 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sNoPrivileged
+metadata:
+  name: no-privileged
+spec:
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]

--- a/infrastructure/k8s/policy/constraints/require-resource-limits-constraint.yaml
+++ b/infrastructure/k8s/policy/constraints/require-resource-limits-constraint.yaml
@@ -1,0 +1,9 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sRequireResourceLimits
+metadata:
+  name: require-resource-limits
+spec:
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]

--- a/infrastructure/k8s/policy/templates/k8s-disallow-latest-tag-template.yaml
+++ b/infrastructure/k8s/policy/templates/k8s-disallow-latest-tag-template.yaml
@@ -1,0 +1,45 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8sdisallowlatesttag
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sDisallowLatestTag
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package k8sdisallowlatesttag
+
+        violation[{"msg": msg}] {
+          c := input_containers[_]
+          has_latest_tag(c.image)
+          msg := sprintf("Container '%s' is using a disallowed image tag 'latest' or no tag in image '%s'.", [c.name, c.image])
+        }
+
+        input_containers[c] {
+          c := input.review.object.spec.containers[_]
+        }
+        input_containers[c] {
+          c := input.review.object.spec.initContainers[_]
+        }
+        input_containers[c] {
+          c := input.review.object.spec.ephemeralContainers[_]
+        }
+
+        has_latest_tag(image) {
+          endswith(image, ":latest")
+        }
+
+        has_latest_tag(image) {
+          not contains(image, ":")
+        }
+
+        has_latest_tag(image) {
+          contains(image, ":")
+          parts := split(image, "/")
+          last_part := parts[count(parts) - 1]
+          not contains(last_part, ":")
+          not contains(last_part, "@")
+        }

--- a/infrastructure/k8s/policy/templates/k8s-no-privileged-template.yaml
+++ b/infrastructure/k8s/policy/templates/k8s-no-privileged-template.yaml
@@ -1,0 +1,29 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8snoprivileged
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sNoPrivileged
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package k8snoprivileged
+
+        violation[{"msg": msg}] {
+          c := input_containers[_]
+          c.securityContext.privileged == true
+          msg := sprintf("Privileged container is not allowed: %v", [c.name])
+        }
+
+        input_containers[c] {
+          c := input.review.object.spec.containers[_]
+        }
+        input_containers[c] {
+          c := input.review.object.spec.initContainers[_]
+        }
+        input_containers[c] {
+          c := input.review.object.spec.ephemeralContainers[_]
+        }

--- a/infrastructure/k8s/policy/templates/k8s-require-resource-limits-template.yaml
+++ b/infrastructure/k8s/policy/templates/k8s-require-resource-limits-template.yaml
@@ -1,0 +1,35 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8srequireresourcelimits
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sRequireResourceLimits
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package k8srequireresourcelimits
+
+        violation[{"msg": msg}] {
+          c := input_containers[_]
+          not c.resources.limits.cpu
+          msg := sprintf("Container '%s' is missing CPU limit.", [c.name])
+        }
+
+        violation[{"msg": msg}] {
+          c := input_containers[_]
+          not c.resources.limits.memory
+          msg := sprintf("Container '%s' is missing memory limit.", [c.name])
+        }
+
+        input_containers[c] {
+          c := input.review.object.spec.containers[_]
+        }
+        input_containers[c] {
+          c := input.review.object.spec.initContainers[_]
+        }
+        input_containers[c] {
+          c := input.review.object.spec.ephemeralContainers[_]
+        }

--- a/infrastructure/k8s/policy/tests/compliant-pod.yaml
+++ b/infrastructure/k8s/policy/tests/compliant-pod.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: compliant-pod
+  namespace: default
+spec:
+  containers:
+    - name: busybox
+      image: busybox:1.36
+      command: ["sh", "-c", "sleep 3600"]
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "128Mi"
+        requests:
+          cpu: "100m"
+          memory: "128Mi"
+      securityContext:
+        privileged: false
+        allowPrivilegeEscalation: false
+        runAsNonRoot: true
+        runAsUser: 1000

--- a/infrastructure/k8s/policy/tests/latest-tag-pod.yaml
+++ b/infrastructure/k8s/policy/tests/latest-tag-pod.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: latest-tag-pod
+  namespace: default
+spec:
+  containers:
+    - name: busybox
+      image: busybox:latest
+      command: ["sh", "-c", "sleep 3600"]
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "128Mi"
+        requests:
+          cpu: "100m"
+          memory: "128Mi"

--- a/infrastructure/k8s/policy/tests/no-resource-limits-pod.yaml
+++ b/infrastructure/k8s/policy/tests/no-resource-limits-pod.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: no-resource-limits-pod
+  namespace: default
+spec:
+  containers:
+    - name: busybox
+      image: busybox:1.36
+      command: ["sh", "-c", "sleep 3600"]

--- a/infrastructure/k8s/policy/tests/privileged-pod.yaml
+++ b/infrastructure/k8s/policy/tests/privileged-pod.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: privileged-pod
+  namespace: default
+spec:
+  containers:
+    - name: busybox
+      image: busybox:1.36
+      command: ["sh", "-c", "sleep 3600"]
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "128Mi"
+        requests:
+          cpu: "100m"
+          memory: "128Mi"

--- a/k8s/monitoring/prometheus-rules.yaml
+++ b/k8s/monitoring/prometheus-rules.yaml
@@ -1,0 +1,24 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: vertexchain-alerts
+  labels:
+    role: alert-rules
+spec:
+  groups:
+    - name: vertexchain-alerts
+      rules:
+        - alert: HighErrorRate
+          expr: rate(http_requests_total{status=~"5.."}[5m]) > 0.05
+          for: 2m
+          labels:
+            severity: warning
+          annotations:
+            summary: "High error rate detected"
+        - alert: ServiceDown
+          expr: up == 0
+          for: 1m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Service is down"


### PR DESCRIPTION
Closes #171 


This PR migrates the existing hand‑rolled Prometheus alert definitions (`monitoring/alert-rules.yml`) to a managed `PrometheusRule` Custom Resource, enabling GitOps‑driven deployment via ArgoCD/Flux.

Changes:
- Added `k8s/monitoring/prometheus-rules.yaml` containing the `PrometheusRule` CR with the `HighErrorRate` and `ServiceDown` alerts.

Why:
- Prevents alert‑drift by storing alert definitions in Git.
- Allows the Prometheus‑Operator to reconcile alerts automatically, ensuring they appear in Prometheus within ~60 seconds of merge.

Verification:
- After merging, the alerts should be visible in the Prometheus UI (or via `kubectl get prometheusrules`) within a minute.

Labels: `infra`, `monitoring`, `gitops`
