### PR TITLE
feat(k8s): enforce Pod Security Standards restricted on all app namespaces

### DIFF
--- a/infrastructure/k8s/namespaces.yaml
+++ b/infrastructure/k8s/namespaces.yaml
@@ -1,0 +1,87 @@
+# infrastructure/k8s/namespaces.yaml
+#
+# Enforces Kubernetes Pod Security Standards (PSS) at the "restricted" level
+# on every namespace that runs VertexChain workloads.
+#
+# PSS restricted requires:
+#   - No privileged containers
+#   - No privilege escalation (allowPrivilegeEscalation: false)
+#   - Containers run as non-root (runAsNonRoot: true)
+#   - Root filesystem read-only (readOnlyRootFilesystem: true) – best-effort
+#   - seccompProfile type Runtime/Default or Localhost
+#   - No host namespaces (hostPID, hostIPC, hostNetwork)
+#   - No host ports
+#   - Capabilities dropped to ALL; only NET_BIND_SERVICE may be added
+#
+# Labels applied:
+#   pod-security.kubernetes.io/enforce: restricted   → reject violating pods at admission
+#   pod-security.kubernetes.io/audit:   restricted   → record violations in audit log
+#   pod-security.kubernetes.io/warn:    restricted   → surface warnings to kubectl users
+#
+# Docs: https://kubernetes.io/docs/concepts/security/pod-security-standards/
+#       https://kubernetes.io/docs/tasks/configure-pod-container/enforce-standards-namespace-labels/
+#
+# Apply with:
+#   kubectl apply -f infrastructure/k8s/namespaces.yaml
+#
+# Note: labeling 'default' does NOT recreate it; kubectl apply only patches labels.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# ── default namespace ─────────────────────────────────────────────────────────
+# The Helm chart deploys to 'default' unless --namespace is overridden.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: default
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest
+---
+# ── vertexchain namespace ─────────────────────────────────────────────────────
+# Dedicated production namespace; use with:
+#   helm upgrade --install vertexchain ./charts/vertexchain -n vertexchain --create-namespace
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vertexchain
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest
+---
+# ── vertexchain-staging namespace ────────────────────────────────────────────
+# Staging environment; mirrors production PSS so misconfigurations are caught
+# before they reach prod.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vertexchain-staging
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest
+---
+# ── vertexchain-dev namespace ─────────────────────────────────────────────────
+# Development environment; enforce=baseline to keep dev ergonomics reasonable
+# while audit/warn at restricted surfaces problems early.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vertexchain-dev
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest

--- a/infrastructure/k8s/policy/tests/pss-restricted-violation-pod.yaml
+++ b/infrastructure/k8s/policy/tests/pss-restricted-violation-pod.yaml
@@ -1,0 +1,81 @@
+# infrastructure/k8s/policy/tests/pss-restricted-violation-pod.yaml
+#
+# PURPOSE: Demonstrate that PSS "restricted" enforcement rejects this pod.
+#
+# This pod violates multiple PSS restricted rules:
+#   1. securityContext.privileged: true          → disallowed at restricted
+#   2. allowPrivilegeEscalation: true            → disallowed at restricted
+#   3. runAsNonRoot: false (runs as root)        → disallowed at restricted
+#   4. seccompProfile not set                    → disallowed at restricted
+#   5. capabilities.drop does not include ALL   → disallowed at restricted
+#
+# Expected behaviour (after applying namespaces.yaml):
+#   $ kubectl apply -f pss-restricted-violation-pod.yaml
+#   Error from server (Forbidden): pods "pss-violation-test" is forbidden:
+#     violates PodSecurity "restricted:latest":
+#       privileged (container "busybox"),
+#       allowPrivilegeEscalation != false (container "busybox"),
+#       unrestricted capabilities (container "busybox"),
+#       runAsNonRoot != true (pod or container "busybox"),
+#       seccompProfile (pod or container "busybox")
+#
+# DO NOT apply this pod to a production cluster; it exists solely as a
+# policy validation fixture.
+#
+# To run the test:
+#   # 1. Ensure namespaces.yaml has been applied:
+#   kubectl apply -f infrastructure/k8s/namespaces.yaml
+#
+#   # 2. Attempt to create the violating pod (should be rejected):
+#   kubectl apply -f infrastructure/k8s/policy/tests/pss-restricted-violation-pod.yaml
+#
+#   # 3. Verify rejection — exit code should be non-zero and stderr contains
+#   #    "violates PodSecurity".
+# ─────────────────────────────────────────────────────────────────────────────
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pss-violation-test
+  namespace: default
+  labels:
+    app: pss-violation-test
+    purpose: policy-test
+  annotations:
+    description: "Intentionally violates PSS restricted — must be rejected by admission control"
+spec:
+  # Violation: host-level network namespace
+  hostNetwork: false   # set to true to add another violation; left false to keep the
+  #                      test focused on container-level violations below
+
+  containers:
+    - name: busybox
+      image: busybox:1.36
+      command: ["sh", "-c", "echo 'This pod should never run'; sleep 1"]
+
+      securityContext:
+        # Violation 1 – privileged container
+        privileged: true
+
+        # Violation 2 – privilege escalation allowed
+        allowPrivilegeEscalation: true
+
+        # Violation 3 – running as root
+        runAsNonRoot: false
+        runAsUser: 0
+
+        # Violation 4 – capabilities not dropped to ALL
+        capabilities:
+          add:
+            - NET_ADMIN   # disallowed; restricted only permits NET_BIND_SERVICE
+          # drop: [ALL]   # intentionally omitted
+
+        # Violation 5 – no seccompProfile (restricted requires RuntimeDefault or Localhost)
+        # seccompProfile: {}   # intentionally absent
+
+      resources:
+        requests:
+          cpu: "10m"
+          memory: "16Mi"
+        limits:
+          cpu: "10m"
+          memory: "16Mi"


### PR DESCRIPTION
## Description

Addresses the lack of Pod Security Standards enforcement flagged in issue #177. A privileged pod is a P0 incident waiting to happen — this change makes the Kubernetes admission controller reject any non-compliant pod spec before it can start.

## Changes

### `infrastructure/k8s/namespaces.yaml` (new)
Labels all VertexChain namespaces with PSS enforcement:

| Namespace | enforce | audit | warn |
|-----------|---------|-------|------|
| `default` | `restricted` | `restricted` | `restricted` |
| `vertexchain` | `restricted` | `restricted` | `restricted` |
| `vertexchain-staging` | `restricted` | `restricted` | `restricted` |
| `vertexchain-dev` | `baseline` | `restricted` | `restricted` |

Dev is `baseline` enforce (keeps local iteration ergonomic) but `restricted` audit/warn so misconfigurations surface before staging/prod.

### `infrastructure/k8s/policy/tests/pss-restricted-violation-pod.yaml` (new)
Policy validation fixture. Intentionally violates five `restricted` rules:
1. `privileged: true`
2. `allowPrivilegeEscalation: true`
3. `runAsNonRoot: false` / `runAsUser: 0`
4. No `seccompProfile`
5. Capabilities not dropped to `ALL`

## Acceptance Criteria Verification

```bash
# Apply namespace labels
kubectl apply -f infrastructure/k8s/namespaces.yaml

# Attempt to create the violating pod — must be rejected:
kubectl apply -f infrastructure/k8s/policy/tests/pss-restricted-violation-pod.yaml
# Error from server (Forbidden): pods "pss-violation-test" is forbidden:
#   violates PodSecurity "restricted:latest":
#     privileged (container "busybox"),
#     allowPrivilegeEscalation != false (container "busybox"),
#     unrestricted capabilities (container "busybox"),
#     runAsNonRoot != true (pod or container "busybox"),
#     seccompProfile (pod or container "busybox")
```

## Notes
- No cluster add-ons required — uses Kubernetes built-in PSS (available since 1.23, GA in 1.25).
- Labeling `default` does **not** recreate it; `kubectl apply` only patches the labels.
- The existing Helm chart deployments should be updated to include a proper `securityContext` before applying to prod (tracked separately).

Closes #177