### PR TITLE
Add Stellar signature verification for opt-in gist authorship

### DIFF
--- a/Backend/package-lock.json
+++ b/Backend/package-lock.json
@@ -17,6 +17,8 @@
         "@nestjs/swagger": "^11.2.6",
         "@nestjs/throttler": "^6.4.0",
         "@nestjs/typeorm": "^11.0.0",
+        "@noble/ed25519": "^3.1.0",
+        "@stellar/stellar-sdk": "^16.0.1",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.2",
         "cookie-parser": "^1.4.7",
@@ -2831,6 +2833,15 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@noble/ed25519": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-3.1.0.tgz",
+      "integrity": "sha512-pfcObRY3CtvwfaG9Mt5XqZdKmAQppl37tHUeuBhDUbiwJBCVY4/A4lbMvb1xKhMDx96AqAqZpMWuBX1HulhX4g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@noble/hashes": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
@@ -2966,6 +2977,87 @@
       "resolved": "https://registry.npmjs.org/@sqltools/formatter/-/formatter-1.2.5.tgz",
       "integrity": "sha512-Uy0+khmZqUrUGm5dmMqVlnvufZRSK0FbYzVgp0UMstm+F5+W2/jnEEQyc9vo1ZR/E5ZI/B1WjjoTqBqwJL6Krw==",
       "license": "MIT"
+    },
+    "node_modules/@stellar/js-xdr": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@stellar/js-xdr/-/js-xdr-4.0.0.tgz",
+      "integrity": "sha512-+NmNa7Tk5BI5XFdy/6xGTqAN4J9a9KgCrCGhj2uEUTCBhLkch0M+QbKzNH8zEnejWe0p8w+0q5hUVX6L3OzoVA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.0.0",
+        "pnpm": ">=9.0.0"
+      }
+    },
+    "node_modules/@stellar/stellar-sdk": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-sdk/-/stellar-sdk-16.0.1.tgz",
+      "integrity": "sha512-bxKohaiyKVqoudRhbOOHeHhHIaeYV5Zab4rCjxhP4Ty1h1ozTLBOv8lWFnZz9ilBzXG8Bb7usQI3rlEcfvUynA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/ed25519": "^3.1.0",
+        "@noble/hashes": "^2.2.0",
+        "@stellar/js-xdr": "4.0.0",
+        "axios": "1.16.1",
+        "base32.js": "^0.1.0",
+        "bignumber.js": "^11.1.1",
+        "buffer": "^6.0.3",
+        "commander": "^14.0.3",
+        "eventsource": "^4.1.0",
+        "feaxios": "^0.0.23",
+        "smol-toml": "^1.6.1",
+        "uint8array-extras": "^1.5.0"
+      },
+      "bin": {
+        "stellar-js": "bin/stellar-js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@stellar/stellar-sdk/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@stellar/stellar-sdk/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/@stellar/stellar-sdk/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/@swc/cli": {
       "version": "0.6.0",
@@ -4588,6 +4680,18 @@
       "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
       "license": "MIT"
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
@@ -4810,7 +4914,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/available-typed-arrays": {
@@ -4826,6 +4929,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/b4a": {
@@ -5073,6 +5188,15 @@
         "bare-path": "^3.0.0"
       }
     },
+    "node_modules/base32.js": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/base32.js/-/base32.js-0.1.0.tgz",
+      "integrity": "sha512-n3TkB02ixgBOhTvANakDb4xaMXnYUVkNoRFJjQflcqMQhyEKxEHdj3E6N8t8sUQ0mjH/3/JxzlXuz3ul/J90pQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -5105,6 +5229,12 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/bignumber.js": {
+      "version": "11.1.5",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-11.1.5.tgz",
+      "integrity": "sha512-6WmzCNtUnfKpbozq+hOgWaZMMzORmYBwF1xZScyoIX3QRYWeKTtxxwDOW5tIz7C9BdjkIYHGTcelCLkXg0mndw==",
+      "license": "MIT"
     },
     "node_modules/bin-version": {
       "version": "6.0.0",
@@ -5681,7 +5811,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -6060,7 +6189,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -6357,7 +6485,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -6689,6 +6816,27 @@
         "bare-events": "^2.7.0"
       }
     },
+    "node_modules/eventsource": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-4.1.0.tgz",
+      "integrity": "sha512-2GuF51iuHX6A9xdTccMTsNb7VO0lHZihApxhvQzJB5A03DvHDd2FQepodbMaztPBmBcE/ox7o2gqaxGhYB9LhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -6964,6 +7112,15 @@
         }
       }
     },
+    "node_modules/feaxios": {
+      "version": "0.0.23",
+      "resolved": "https://registry.npmjs.org/feaxios/-/feaxios-0.0.23.tgz",
+      "integrity": "sha512-eghR0A21fvbkcQBgZuMfQhrXxJzC0GNUGC9fXhBge33D+mFDTwl0aJ35zoQQn575BhyjQitRc5N4f+L4cP708g==",
+      "license": "MIT",
+      "dependencies": {
+        "is-retry-allowed": "^3.0.0"
+      }
+    },
     "node_modules/fflate": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
@@ -7119,6 +7276,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -7182,7 +7359,6 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
       "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -7209,7 +7385,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -7219,7 +7394,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -7703,6 +7877,19 @@
         "node": ">=10.19.0"
       }
     },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/human-signals": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
@@ -7986,6 +8173,18 @@
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
+    },
+    "node_modules/is-retry-allowed": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-3.0.0.tgz",
+      "integrity": "sha512-9xH0xvoggby+u0uGF7cZXdrutWiBiaFG8ZT4YFPXL8NzkyAwX3AKGLeFQLvzDpM430+nDFBZ1LHkie/8ocL06A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
@@ -10363,6 +10562,15 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -11062,6 +11270,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/smol-toml": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.0.tgz",
+      "integrity": "sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
       }
     },
     "node_modules/sort-keys": {

--- a/Backend/package.json
+++ b/Backend/package.json
@@ -35,6 +35,8 @@
     "@nestjs/swagger": "^11.2.6",
     "@nestjs/throttler": "^6.4.0",
     "@nestjs/typeorm": "^11.0.0",
+    "@noble/ed25519": "^3.1.0",
+    "@stellar/stellar-sdk": "^16.0.1",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",
     "cookie-parser": "^1.4.7",

--- a/Backend/src/auth/auth.module.ts
+++ b/Backend/src/auth/auth.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { StellarAuthGuard } from './guards/stellar-auth.guard';
+
+@Module({
+  imports: [ConfigModule],
+  providers: [StellarAuthGuard],
+  exports: [StellarAuthGuard],
+})
+export class AuthModule {}

--- a/Backend/src/auth/decorators/stellar-verified.decorator.ts
+++ b/Backend/src/auth/decorators/stellar-verified.decorator.ts
@@ -1,0 +1,9 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import { StellarVerified } from '../interfaces/stellar-verified.interface';
+
+export const StellarVerifiedUser = createParamDecorator(
+  (_data: unknown, ctx: ExecutionContext): StellarVerified | null => {
+    const request = ctx.switchToHttp().getRequest();
+    return request.stellarVerified ?? null;
+  },
+);

--- a/Backend/src/auth/guards/stellar-auth.guard.spec.ts
+++ b/Backend/src/auth/guards/stellar-auth.guard.spec.ts
@@ -1,0 +1,183 @@
+import { UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { StellarAuthGuard } from './stellar-auth.guard';
+import { StrKey } from '@stellar/stellar-sdk';
+import { verifyAsync } from '@noble/ed25519';
+
+jest.mock('@stellar/stellar-sdk', () => ({
+  StrKey: {
+    decodeEd25519PublicKey: jest.fn(),
+  },
+}));
+
+jest.mock('@noble/ed25519', () => ({
+  verifyAsync: jest.fn(),
+}));
+
+function mockExecutionContext(headers: Record<string, string>, body: unknown) {
+  const request: Record<string, unknown> = { headers, body };
+  return {
+    switchToHttp: () => ({
+      getRequest: () => request,
+    }),
+  } as any;
+}
+
+describe('StellarAuthGuard', () => {
+  let guard: StellarAuthGuard;
+  let configService: jest.Mocked<ConfigService>;
+
+  beforeEach(async () => {
+    configService = { get: jest.fn().mockReturnValue(300) } as any;
+    guard = new StellarAuthGuard(configService);
+    jest.clearAllMocks();
+  });
+
+  describe('anonymous access', () => {
+    it('should allow requests without any X-Stellar-* headers', async () => {
+      const context = mockExecutionContext({}, { content: 'hello', lat: 0, lon: 0 });
+      const result = await guard.canActivate(context);
+      expect(result).toBe(true);
+    });
+
+    it('should set stellarVerified to null on anonymous requests', async () => {
+      const context = mockExecutionContext({}, { content: 'hello', lat: 0, lon: 0 });
+      await guard.canActivate(context);
+      const request = context.switchToHttp().getRequest();
+      expect(request.stellarVerified).toBeNull();
+    });
+  });
+
+  describe('header validation', () => {
+    it('should reject when only some headers are provided', async () => {
+      const context = mockExecutionContext(
+        { 'x-stellar-signature': 'sig' },
+        { content: 'hello', lat: 0, lon: 0 },
+      );
+      await expect(guard.canActivate(context)).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('should reject with message about all headers required', async () => {
+      const context = mockExecutionContext(
+        { 'x-stellar-address': 'GABC' },
+        { content: 'hello', lat: 0, lon: 0 },
+      );
+      await expect(guard.canActivate(context)).rejects.toThrow(
+        'All X-Stellar-* headers must be provided',
+      );
+    });
+  });
+
+  describe('replay protection', () => {
+    it('should reject timestamps older than the window', async () => {
+      const oldTimestamp = Math.floor(Date.now() / 1000) - 600;
+      const context = mockExecutionContext(
+        {
+          'x-stellar-signature': 'sig',
+          'x-stellar-address': 'GABC',
+          'x-stellar-timestamp': String(oldTimestamp),
+        },
+        { content: 'hello', lat: 0, lon: 0 },
+      );
+      await expect(guard.canActivate(context)).rejects.toThrow(
+        'outside the accepted window',
+      );
+    });
+
+    it('should reject timestamps in the future beyond clock skew', async () => {
+      const futureTimestamp = Math.floor(Date.now() / 1000) + 10;
+      const context = mockExecutionContext(
+        {
+          'x-stellar-signature': 'sig',
+          'x-stellar-address': 'GABC',
+          'x-stellar-timestamp': String(futureTimestamp),
+        },
+        { content: 'hello', lat: 0, lon: 0 },
+      );
+      await expect(guard.canActivate(context)).rejects.toThrow(
+        'outside the accepted window',
+      );
+    });
+
+    it('should accept timestamps within the window', async () => {
+      const validTimestamp = Math.floor(Date.now() / 1000) - 10;
+      (StrKey.decodeEd25519PublicKey as jest.Mock).mockReturnValue(
+        new Uint8Array(32).fill(1),
+      );
+      (verifyAsync as jest.Mock).mockResolvedValue(true);
+
+      const context = mockExecutionContext(
+        {
+          'x-stellar-signature': '00'.repeat(64),
+          'x-stellar-address': 'GABC',
+          'x-stellar-timestamp': String(validTimestamp),
+        },
+        { content: 'hello', lat: 0, lon: 0 },
+      );
+      const result = await guard.canActivate(context);
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('signature verification', () => {
+    it('should reject an invalid Stellar address', async () => {
+      (StrKey.decodeEd25519PublicKey as jest.Mock).mockImplementation(() => {
+        throw new Error('invalid address');
+      });
+
+      const validTimestamp = Math.floor(Date.now() / 1000) - 10;
+      const context = mockExecutionContext(
+        {
+          'x-stellar-signature': '00'.repeat(64),
+          'x-stellar-address': 'INVALID',
+          'x-stellar-timestamp': String(validTimestamp),
+        },
+        { content: 'hello', lat: 0, lon: 0 },
+      );
+      await expect(guard.canActivate(context)).rejects.toThrow(
+        'Invalid X-Stellar-Address',
+      );
+    });
+
+    it('should reject when signature verification fails', async () => {
+      (StrKey.decodeEd25519PublicKey as jest.Mock).mockReturnValue(
+        new Uint8Array(32).fill(1),
+      );
+      (verifyAsync as jest.Mock).mockResolvedValue(false);
+
+      const validTimestamp = Math.floor(Date.now() / 1000) - 10;
+      const context = mockExecutionContext(
+        {
+          'x-stellar-signature': '00'.repeat(64),
+          'x-stellar-address': 'GABC',
+          'x-stellar-timestamp': String(validTimestamp),
+        },
+        { content: 'hello', lat: 0, lon: 0 },
+      );
+      await expect(guard.canActivate(context)).rejects.toThrow(
+        'X-Stellar-Signature verification failed',
+      );
+    });
+
+    it('should attach verified info on successful verification', async () => {
+      const pubKey = new Uint8Array(32).fill(42);
+      (StrKey.decodeEd25519PublicKey as jest.Mock).mockReturnValue(pubKey);
+      (verifyAsync as jest.Mock).mockResolvedValue(true);
+
+      const validTimestamp = Math.floor(Date.now() / 1000) - 10;
+      const context = mockExecutionContext(
+        {
+          'x-stellar-signature': '00'.repeat(64),
+          'x-stellar-address': 'GABCDEF',
+          'x-stellar-timestamp': String(validTimestamp),
+        },
+        { content: 'hello', lat: 0, lon: 0 },
+      );
+      await guard.canActivate(context);
+      const request = context.switchToHttp().getRequest();
+      expect(request.stellarVerified).toBeDefined();
+      expect(request.stellarVerified.address).toBe('GABCDEF');
+      expect(request.stellarVerified.verifiedAt).toBeInstanceOf(Date);
+    });
+  });
+});

--- a/Backend/src/auth/guards/stellar-auth.guard.ts
+++ b/Backend/src/auth/guards/stellar-auth.guard.ts
@@ -1,0 +1,98 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { StrKey } from '@stellar/stellar-sdk';
+import { verifyAsync } from '@noble/ed25519';
+import { createHash } from 'crypto';
+
+const DEFAULT_REPLAY_WINDOW_SECONDS = 300;
+
+function canonicalizeBody(body: unknown): string {
+  if (body === null || body === undefined) return '';
+  if (typeof body !== 'object' || Array.isArray(body)) return JSON.stringify(body);
+  const keys = Object.keys(body as Record<string, unknown>).sort();
+  const canonical: Record<string, unknown> = {};
+  for (const key of keys) {
+    const value = (body as Record<string, unknown>)[key];
+    canonical[key] = value !== null && typeof value === 'object' && !Array.isArray(value)
+      ? JSON.parse(canonicalizeBody(value))
+      : value;
+  }
+  return JSON.stringify(canonical);
+}
+
+@Injectable()
+export class StellarAuthGuard implements CanActivate {
+  private readonly replayWindowSeconds: number;
+
+  constructor(private readonly configService: ConfigService) {
+    this.replayWindowSeconds = this.configService.get<number>(
+      'STELLAR_REPLAY_WINDOW_SECONDS',
+      DEFAULT_REPLAY_WINDOW_SECONDS,
+    );
+  }
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+    const signature = request.headers['x-stellar-signature'] as string | undefined;
+    const address = request.headers['x-stellar-address'] as string | undefined;
+    const timestamp = request.headers['x-stellar-timestamp'] as string | undefined;
+
+    if (!signature && !address && !timestamp) {
+      request.stellarVerified = null;
+      return true;
+    }
+
+    if (!signature || !address || !timestamp) {
+      throw new UnauthorizedException(
+        'All X-Stellar-* headers must be provided when using Stellar auth',
+      );
+    }
+
+    const now = Math.floor(Date.now() / 1000);
+    const ts = parseInt(timestamp, 10);
+    if (isNaN(ts) || now - ts > this.replayWindowSeconds || ts > now + 5) {
+      throw new UnauthorizedException('X-Stellar-Timestamp is outside the accepted window');
+    }
+
+    let publicKey: Uint8Array;
+    try {
+      publicKey = StrKey.decodeEd25519PublicKey(address);
+    } catch {
+      throw new UnauthorizedException('Invalid X-Stellar-Address');
+    }
+
+    const body = request.body ?? {};
+    const canonicalBody = canonicalizeBody(body);
+    const bodyHash = createHash('sha256').update(canonicalBody, 'utf-8').digest();
+    const message = `${timestamp}.${bodyHash.toString('hex')}`;
+    const messageBytes = new TextEncoder().encode(message);
+
+    let sigBytes: Uint8Array;
+    try {
+      sigBytes = Buffer.from(signature, 'hex');
+    } catch {
+      throw new UnauthorizedException('Invalid X-Stellar-Signature encoding');
+    }
+
+    try {
+      const valid = await verifyAsync(sigBytes, messageBytes, publicKey);
+      if (!valid) {
+        throw new UnauthorizedException('X-Stellar-Signature verification failed');
+      }
+    } catch {
+      throw new UnauthorizedException('X-Stellar-Signature verification failed');
+    }
+
+    request.stellarVerified = {
+      address,
+      verifiedAt: new Date(),
+    };
+
+    return true;
+  }
+}

--- a/Backend/src/auth/interfaces/stellar-verified.interface.ts
+++ b/Backend/src/auth/interfaces/stellar-verified.interface.ts
@@ -1,0 +1,4 @@
+export interface StellarVerified {
+  address: string;
+  verifiedAt: Date;
+}

--- a/Backend/src/database/migrations/1700000000003-AddAuthorVerifiedAt.ts
+++ b/Backend/src/database/migrations/1700000000003-AddAuthorVerifiedAt.ts
@@ -1,0 +1,16 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddAuthorVerifiedAt1700000000003 implements MigrationInterface {
+  name = 'AddAuthorVerifiedAt1700000000003';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "gists"
+        ADD COLUMN IF NOT EXISTS "author_verified_at" TIMESTAMPTZ
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "gists" DROP COLUMN IF EXISTS "author_verified_at"`);
+  }
+}

--- a/Backend/src/gists/entities/gist.entity.ts
+++ b/Backend/src/gists/entities/gist.entity.ts
@@ -25,6 +25,9 @@ export class Gist {
   @Column({ type: 'varchar', length: 80, nullable: true })
   author: string | null;
 
+  @Column({ type: 'timestamptz', nullable: true })
+  author_verified_at: Date | null;
+
   @Column({ type: 'varchar', length: 100, nullable: true })
   previous_cid: string | null;
 

--- a/Backend/src/gists/gist.repository.ts
+++ b/Backend/src/gists/gist.repository.ts
@@ -21,6 +21,7 @@ export interface CreateGistData {
   stellar_gist_id?: string;
   tx_hash?: string;
   author?: string;
+  author_verified_at?: Date | null;
 }
 
 export interface UpdateGistData {
@@ -53,26 +54,27 @@ export class GistRepository {
       stellar_gist_id = null,
       tx_hash = null,
       author = null,
+      author_verified_at = null,
     } = data;
 
     const result = await this.dataSource.query<Gist[]>(
       `
       INSERT INTO gists (
         content, location, location_cell,
-        content_hash, stellar_gist_id, tx_hash, author
+        content_hash, stellar_gist_id, tx_hash, author, author_verified_at
       )
       VALUES (
         $1,
         ST_SetSRID(ST_MakePoint($2, $3), 4326)::geography,
-        $4, $5, $6, $7, $8
+        $4, $5, $6, $7, $8, $9
       )
       RETURNING
         id, content, location_cell, content_hash,
-        stellar_gist_id, tx_hash, author, previous_cid, edited_at, created_at,
+        stellar_gist_id, tx_hash, author, author_verified_at, previous_cid, edited_at, created_at,
         ST_X(location::geometry) AS lon,
         ST_Y(location::geometry) AS lat
       `,
-      [content, lon, lat, location_cell, content_hash, stellar_gist_id, tx_hash, author],
+      [content, lon, lat, location_cell, content_hash, stellar_gist_id, tx_hash, author, author_verified_at],
     );
 
     return result[0];
@@ -100,6 +102,8 @@ export class GistRepository {
         g.content_hash,
         g.stellar_gist_id,
         g.tx_hash,
+        g.author,
+        g.author_verified_at,
         g.created_at,
         ST_X(g.location::geometry)                              AS lon,
         ST_Y(g.location::geometry)                              AS lat,
@@ -128,7 +132,7 @@ export class GistRepository {
       `
       SELECT
         id, content, location_cell, content_hash,
-        stellar_gist_id, tx_hash, author, previous_cid, edited_at, created_at,
+        stellar_gist_id, tx_hash, author, author_verified_at, previous_cid, edited_at, created_at,
         ST_X(location::geometry) AS lon,
         ST_Y(location::geometry) AS lat
       FROM gists
@@ -153,7 +157,7 @@ export class GistRepository {
       WHERE id = $1
       RETURNING
         id, content, location_cell, content_hash,
-        stellar_gist_id, tx_hash, author, previous_cid, edited_at, created_at,
+        stellar_gist_id, tx_hash, author, author_verified_at, previous_cid, edited_at, created_at,
         ST_X(location::geometry) AS lon,
         ST_Y(location::geometry) AS lat
       `,
@@ -167,7 +171,7 @@ export class GistRepository {
       `
       SELECT
         id, content, location_cell, content_hash,
-        stellar_gist_id, tx_hash, created_at,
+        stellar_gist_id, tx_hash, author, author_verified_at, created_at,
         ST_X(location::geometry) AS lon,
         ST_Y(location::geometry) AS lat
       FROM gists

--- a/Backend/src/gists/gists.controller.spec.ts
+++ b/Backend/src/gists/gists.controller.spec.ts
@@ -2,9 +2,21 @@ jest.mock('../common/utils/sanitize', () => ({
   stripHtml: jest.fn((text: string) => text.replace(/<[^>]*>/g, '')),
 }));
 
+jest.mock('@stellar/stellar-sdk', () => ({
+  StrKey: {
+    decodeEd25519PublicKey: jest.fn(),
+  },
+}));
+
+jest.mock('@noble/ed25519', () => ({
+  verifyAsync: jest.fn(),
+}));
+
 import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
 import { GistsController } from './gists.controller';
 import { GistsService } from './gists.service';
+import { StellarAuthGuard } from '../auth/guards/stellar-auth.guard';
 import { CreateGistDto } from './dto/create-gist.dto';
 import { QueryGistsDto } from './dto/query-gists.dto';
 import { UpdateGistDto } from './dto/update-gist.dto';
@@ -30,6 +42,14 @@ describe('GistsController', () => {
           provide: GistsService,
           useValue: mockGistsService,
         },
+        {
+          provide: StellarAuthGuard,
+          useValue: { canActivate: jest.fn().mockReturnValue(true) },
+        },
+        {
+          provide: ConfigService,
+          useValue: { get: jest.fn() },
+        },
       ],
     }).compile();
 
@@ -48,8 +68,8 @@ describe('GistsController', () => {
       );
       jest.spyOn(service, 'createBatch').mockResolvedValueOnce(result);
 
-      await expect(controller.createBatch(gists)).resolves.toEqual(result);
-      expect(service.createBatch).toHaveBeenCalledWith(gists);
+      await expect(controller.createBatch(gists, null)).resolves.toEqual(result);
+      expect(service.createBatch).toHaveBeenCalledWith(gists, null);
     });
   });
 
@@ -63,6 +83,7 @@ describe('GistsController', () => {
       stellar_gist_id: null,
       tx_hash: null,
       author: null,
+      author_verified_at: null,
       previous_cid: null,
       edited_at: null,
       location: 'POINT(7.4951 9.0579)',
@@ -83,9 +104,9 @@ describe('GistsController', () => {
 
       jest.spyOn(service, 'create').mockResolvedValueOnce(result);
 
-      const response = await controller.create(dto);
+      const response = await controller.create(dto, null);
 
-      expect(service.create).toHaveBeenCalledWith(dto);
+      expect(service.create).toHaveBeenCalledWith(dto, null);
       expect(response).toEqual(result);
     });
 
@@ -99,9 +120,9 @@ describe('GistsController', () => {
 
       jest.spyOn(service, 'create').mockResolvedValueOnce(result);
 
-      const response = await controller.create(dto);
+      const response = await controller.create(dto, null);
 
-      expect(service.create).toHaveBeenCalledWith(dto);
+      expect(service.create).toHaveBeenCalledWith(dto, null);
       expect(response).toEqual(result);
     });
 
@@ -115,7 +136,7 @@ describe('GistsController', () => {
 
       jest.spyOn(service, 'create').mockRejectedValueOnce(error);
 
-      await expect(controller.create(dto)).rejects.toThrow('Database error');
+      await expect(controller.create(dto, null)).rejects.toThrow('Database error');
     });
   });
 

--- a/Backend/src/gists/gists.controller.ts
+++ b/Backend/src/gists/gists.controller.ts
@@ -9,6 +9,7 @@ import {
   Param,
   Query,
   ParseArrayPipe,
+  UseGuards,
 } from '@nestjs/common';
 import { Throttle, SkipThrottle } from '@nestjs/throttler';
 import { ApiBody, ApiOperation, ApiTags, ApiParam, ApiResponse } from '@nestjs/swagger';
@@ -16,6 +17,9 @@ import { GistsService } from './gists.service';
 import { CreateGistDto } from './dto/create-gist.dto';
 import { QueryGistsDto } from './dto/query-gists.dto';
 import { UpdateGistDto } from './dto/update-gist.dto';
+import { StellarAuthGuard } from '../auth/guards/stellar-auth.guard';
+import { StellarVerifiedUser } from '../auth/decorators/stellar-verified.decorator';
+import { StellarVerified } from '../auth/interfaces/stellar-verified.interface';
 
 const MAX_GISTS_PER_BATCH = 10;
 
@@ -41,21 +45,27 @@ export class GistsController {
   constructor(private readonly gistsService: GistsService) {}
 
   @Post()
+  @UseGuards(StellarAuthGuard)
   @Throttle({ default: { limit: 10, ttl: 60000 } })
   @ApiOperation({ summary: 'Post a new anonymous gist at a location' })
-  create(@Body() dto: CreateGistDto) {
-    return this.gistsService.create(dto);
+  create(
+    @Body() dto: CreateGistDto,
+    @StellarVerifiedUser() stellarVerified: StellarVerified | null,
+  ) {
+    return this.gistsService.create(dto, stellarVerified);
   }
 
   @Post('batch')
+  @UseGuards(StellarAuthGuard)
   @Throttle({ default: { limit: 10, ttl: 60000 } })
   @ApiOperation({ summary: 'Post several anonymous gists in one burst' })
   @ApiBody({ type: [CreateGistDto] })
   createBatch(
     @Body(new ParseGistsBatchPipe())
     dtos: CreateGistDto[],
+    @StellarVerifiedUser() stellarVerified: StellarVerified | null,
   ) {
-    return this.gistsService.createBatch(dtos);
+    return this.gistsService.createBatch(dtos, stellarVerified);
   }
 
   @Get()

--- a/Backend/src/gists/gists.module.ts
+++ b/Backend/src/gists/gists.module.ts
@@ -8,9 +8,10 @@ import { GeoModule } from '../geo/geo.module';
 import { IpfsModule } from '../ipfs/ipfs.module';
 import { SorobanModule } from '../soroban/soroban.module';
 import { CacheModule } from '../cache/cache.module';
+import { AuthModule } from '../auth/auth.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Gist]), GeoModule, IpfsModule, SorobanModule, CacheModule],
+  imports: [TypeOrmModule.forFeature([Gist]), GeoModule, IpfsModule, SorobanModule, CacheModule, AuthModule],
   controllers: [GistsController],
   providers: [GistRepository, GistsService],
   exports: [GistsService],

--- a/Backend/src/gists/gists.service.spec.ts
+++ b/Backend/src/gists/gists.service.spec.ts
@@ -23,6 +23,7 @@ const mockGist = (overrides?: Partial<Gist>): Gist => ({
   stellar_gist_id: '1000',
   tx_hash: 'mock_tx_abc',
   author: 'GABC',
+  author_verified_at: null,
   previous_cid: null,
   edited_at: null,
   location: null,
@@ -91,6 +92,7 @@ describe('GistsService', () => {
         { content: 'First', lat: 9.0579, lon: 7.4951 },
         { content: 'Second', lat: 9.058, lon: 7.4952, author: 'GABC' },
       ];
+      const stellarVerified = null;
       geoService.encode.mockReturnValueOnce('cell-1').mockReturnValueOnce('cell-2');
       ipfsService.pinJsonBatch.mockResolvedValue([
         { cid: 'cid-1', mock: true },
@@ -179,6 +181,8 @@ describe('GistsService', () => {
         content_hash: 'mock_Qmabc',
         stellar_gist_id: '42',
         tx_hash: 'tx42',
+        author: undefined,
+        author_verified_at: null,
       });
     });
 

--- a/Backend/src/gists/gists.service.spec.ts
+++ b/Backend/src/gists/gists.service.spec.ts
@@ -92,7 +92,6 @@ describe('GistsService', () => {
         { content: 'First', lat: 9.0579, lon: 7.4951 },
         { content: 'Second', lat: 9.058, lon: 7.4952, author: 'GABC' },
       ];
-      const stellarVerified = null;
       geoService.encode.mockReturnValueOnce('cell-1').mockReturnValueOnce('cell-2');
       ipfsService.pinJsonBatch.mockResolvedValue([
         { cid: 'cid-1', mock: true },

--- a/Backend/src/gists/gists.service.ts
+++ b/Backend/src/gists/gists.service.ts
@@ -17,6 +17,7 @@ import { CacheService } from '../cache/cache.service';
 import { Gist } from './entities/gist.entity';
 import { PaginatedResponse } from '../common/utils/pagination.helper';
 import { stripHtml } from '../common/utils/sanitize';
+import { StellarVerified } from '../auth/interfaces/stellar-verified.interface';
 
 const EDIT_WINDOW_MS = 60_000;
 
@@ -32,7 +33,7 @@ export class GistsService {
     private readonly cacheService: CacheService,
   ) {}
 
-  async create(dto: CreateGistDto): Promise<Gist> {
+  async create(dto: CreateGistDto, stellarVerified?: StellarVerified | null): Promise<Gist> {
     // Issue 87 — sanitize content before storing
     const content = stripHtml(dto.content);
 
@@ -46,7 +47,8 @@ export class GistsService {
       created_at: new Date().toISOString(),
     });
 
-    const { gistId, txHash } = await this.sorobanService.postGist(locationCell, cid, dto.author);
+    const author = stellarVerified ? stellarVerified.address : dto.author;
+    const { gistId, txHash } = await this.sorobanService.postGist(locationCell, cid, author);
 
     this.logger.log(`Gist posted → cell=${locationCell} cid=${cid} gistId=${gistId}`);
 
@@ -58,7 +60,8 @@ export class GistsService {
       content_hash: cid,
       stellar_gist_id: gistId,
       tx_hash: txHash,
-      author: dto.author,
+      author,
+      author_verified_at: stellarVerified ? stellarVerified.verifiedAt : null,
     });
 
     // Invalidate nearby cache for the affected area
@@ -67,8 +70,11 @@ export class GistsService {
     return gist;
   }
 
-  async createBatch(dtos: CreateGistDto[]): Promise<Gist[]> {
+  async createBatch(dtos: CreateGistDto[], stellarVerified?: StellarVerified | null): Promise<Gist[]> {
     const createdAt = new Date().toISOString();
+    const author = stellarVerified ? stellarVerified.address : undefined;
+    const authorVerifiedAt = stellarVerified ? stellarVerified.verifiedAt : null;
+
     const prepared = dtos.map((dto) => {
       const content = stripHtml(dto.content);
       const locationCell = this.geoService.encode(dto.lat, dto.lon);
@@ -77,6 +83,7 @@ export class GistsService {
         dto,
         content,
         locationCell,
+        effectiveAuthor: author ?? dto.author,
         payload: {
           content,
           lat: dto.lat,
@@ -90,12 +97,12 @@ export class GistsService {
     const pins = await this.ipfsService.pinJsonBatch(prepared.map(({ payload }) => payload));
 
     const gists = await Promise.all(
-      prepared.map(async ({ dto, content, locationCell }, index) => {
+      prepared.map(async ({ dto, content, locationCell, effectiveAuthor }, index) => {
         const { cid } = pins[index];
         const { gistId, txHash } = await this.sorobanService.postGist(
           locationCell,
           cid,
-          dto.author,
+          effectiveAuthor,
         );
 
         this.logger.log(`Batch gist posted → cell=${locationCell} cid=${cid} gistId=${gistId}`);
@@ -108,6 +115,8 @@ export class GistsService {
           content_hash: cid,
           stellar_gist_id: gistId,
           tx_hash: txHash,
+          author: effectiveAuthor,
+          author_verified_at: authorVerifiedAt,
         });
       }),
     );


### PR DESCRIPTION
## Summary

Implemented a production-ready fix while maintaining the existing architecture and coding standards.

### Changes

- Added `StellarAuthGuard` that verifies ed25519 signatures via `X-Stellar-Signature`, `X-Stellar-Address`, and `X-Stellar-Timestamp` headers
- Added replay window protection (configurable, default 300s) to prevent replay attacks
- Added body canonicalization (sorted keys) before hashing for signature verification
- Added `StellarVerifiedUser` decorator for extracting verified author info from requests
- Added `author_verified_at` migration for tracking when authorship was cryptographically verified
- Updated `GistRepository`, `GistsService`, and `GistsController` to support verified authorship
- Anonymous posting remains the default; only requests with valid Stellar signatures get verified authorship
- Added unit tests for the auth guard
- Updated existing tests for controller and service changes
- Verified linting
- Verified build
- Ensured no unrelated changes were introduced

Closes #92