### PR TITLE
Add Idempotency-Key middleware for POST gists endpoint

### DIFF
--- a/Backend/.env.example
+++ b/Backend/.env.example
@@ -130,3 +130,10 @@ THROTTLE_LIMIT=10
 # Example with ElastiCache: redis://my-cluster.xxxxxx.use1.cache.amazonaws.com:6379/0
 # Leave empty to disable caching (degrades gracefully)
 REDIS_URL=
+
+# IDEMPOTENCY_TTL_SECONDS (optional)
+# Time-to-live in seconds for cached idempotency key entries
+# The middleware stores POST/PATCH/PUT responses keyed by the
+# Idempotency-Key header and replays them within this window
+# Default: 86400 (24 hours)
+IDEMPOTENCY_TTL_SECONDS=86400

--- a/Backend/src/common/middleware/idempotency.middleware.spec.ts
+++ b/Backend/src/common/middleware/idempotency.middleware.spec.ts
@@ -1,0 +1,156 @@
+import * as express from 'express';
+import * as request from 'supertest';
+import { CacheService } from '../../cache/cache.service';
+import { idempotencyMiddleware } from './idempotency.middleware';
+
+function createMockCacheService(): jest.Mocked<CacheService> {
+  return {
+    get: jest.fn(),
+    set: jest.fn(),
+    del: jest.fn(),
+    delPattern: jest.fn(),
+    getMetrics: jest.fn(),
+    resetMetrics: jest.fn(),
+    onModuleInit: jest.fn(),
+    onModuleDestroy: jest.fn(),
+  } as unknown as jest.Mocked<CacheService>;
+}
+
+describe('Idempotency-Key middleware', () => {
+  let app: express.Express;
+  let cache: jest.Mocked<CacheService>;
+
+  beforeEach(() => {
+    cache = createMockCacheService();
+    app = express();
+    app.use(express.json());
+    app.use(idempotencyMiddleware(cache));
+
+    app.post('/gists', (req, res) => {
+      res.status(200).json({ id: 'gist-123', content: req.body.content });
+    });
+
+    app.post('/gists/batch', (req, res) => {
+      res.status(200).json({ count: req.body.length });
+    });
+
+    app.get('/health', (req, res) => {
+      res.status(200).json({ status: 'ok' });
+    });
+  });
+
+  it('passes through when no Idempotency-Key header is present', async () => {
+    cache.get.mockResolvedValue(null);
+
+    const res = await request(app).post('/gists').send({ content: 'hello' }).expect(200);
+
+    expect(res.body).toEqual({ id: 'gist-123', content: 'hello' });
+    expect(cache.get).not.toHaveBeenCalled();
+  });
+
+  it('passes through for GET requests regardless of header', async () => {
+    const res = await request(app).get('/health').set('Idempotency-Key', 'key-1').expect(200);
+
+    expect(res.body).toEqual({ status: 'ok' });
+    expect(cache.get).not.toHaveBeenCalled();
+  });
+
+  it('caches the first POST response and replays it on a second identical request', async () => {
+    cache.get.mockResolvedValue(null);
+
+    const res1 = await request(app)
+      .post('/gists')
+      .set('Idempotency-Key', 'key-1')
+      .send({ content: 'hello' })
+      .expect(200);
+
+    expect(res1.body).toEqual({ id: 'gist-123', content: 'hello' });
+    expect(cache.set).toHaveBeenCalledTimes(1);
+
+    const setArgs = cache.set.mock.calls[0];
+    expect(setArgs[0]).toBe('idemp:key-1');
+    expect(setArgs[2]).toBe(86400);
+
+    cache.get.mockResolvedValue(setArgs[1]);
+
+    const res2 = await request(app)
+      .post('/gists')
+      .set('Idempotency-Key', 'key-1')
+      .send({ content: 'hello' })
+      .expect(200);
+
+    expect(res2.body).toEqual({ id: 'gist-123', content: 'hello' });
+    expect(res2.headers['idempotency-replayed']).toBe('true');
+  });
+
+  it('returns 422 when the same key is used with a different body', async () => {
+    cache.get.mockResolvedValue(null);
+
+    await request(app)
+      .post('/gists')
+      .set('Idempotency-Key', 'key-2')
+      .send({ content: 'first' })
+      .expect(200);
+
+    const setArgs = cache.set.mock.calls[0];
+    cache.get.mockResolvedValue(setArgs[1]);
+
+    const res = await request(app)
+      .post('/gists')
+      .set('Idempotency-Key', 'key-2')
+      .send({ content: 'different' })
+      .expect(422);
+
+    expect(res.body).toEqual({
+      error: 'Idempotency-Key already used with a different request',
+    });
+  });
+
+  it('returns 422 when the same key is used on a different path', async () => {
+    cache.get.mockResolvedValue(null);
+
+    await request(app)
+      .post('/gists')
+      .set('Idempotency-Key', 'key-3')
+      .send({ content: 'hello' })
+      .expect(200);
+
+    const setArgs = cache.set.mock.calls[0];
+    cache.get.mockResolvedValue(setArgs[1]);
+
+    const res = await request(app)
+      .post('/gists/batch')
+      .set('Idempotency-Key', 'key-3')
+      .send([{ content: 'hello' }])
+      .expect(422);
+
+    expect(res.body).toEqual({
+      error: 'Idempotency-Key already used with a different request',
+    });
+  });
+
+  it('uses configurable TTL', async () => {
+    const origTtl = process.env.IDEMPOTENCY_TTL_SECONDS;
+    process.env.IDEMPOTENCY_TTL_SECONDS = '3600';
+
+    cache.get.mockResolvedValue(null);
+
+    await request(app)
+      .post('/gists')
+      .set('Idempotency-Key', 'key-ttl')
+      .send({ content: 'test' })
+      .expect(200);
+
+    expect(cache.set.mock.calls[0][2]).toBe(3600);
+
+    process.env.IDEMPOTENCY_TTL_SECONDS = origTtl;
+  });
+
+  it('does not cache responses for requests without Idempotency-Key', async () => {
+    cache.get.mockResolvedValue(null);
+
+    await request(app).post('/gists').send({ content: 'no-key' }).expect(200);
+
+    expect(cache.set).not.toHaveBeenCalled();
+  });
+});

--- a/Backend/src/common/middleware/idempotency.middleware.ts
+++ b/Backend/src/common/middleware/idempotency.middleware.ts
@@ -1,0 +1,60 @@
+import { Request, Response, NextFunction } from 'express';
+import { createHash } from 'crypto';
+import { CacheService } from '../../cache/cache.service';
+
+interface CachedEntry {
+  status: number;
+  body: unknown;
+  reqHash: string;
+}
+
+function hashRequest(method: string, path: string, body: unknown): string {
+  return createHash('sha256')
+    .update(`${method}:${path}:${JSON.stringify(body)}`)
+    .digest('hex');
+}
+
+export function idempotencyMiddleware(cacheService: CacheService) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    if (!['POST', 'PATCH', 'PUT'].includes(req.method)) {
+      return next();
+    }
+
+    const idempotencyKey = req.headers['idempotency-key'] as string | undefined;
+    if (!idempotencyKey) {
+      return next();
+    }
+
+    const cacheKey = `idemp:${idempotencyKey}`;
+    const reqHash = hashRequest(req.method, req.path, req.body);
+
+    void (async () => {
+      const cached = await cacheService.get<CachedEntry>(cacheKey);
+      if (cached) {
+        if (cached.reqHash !== reqHash) {
+          res.status(422).json({
+            error: 'Idempotency-Key already used with a different request',
+          });
+          return;
+        }
+
+        res.setHeader('Idempotency-Replayed', 'true');
+        res.status(cached.status).json(cached.body);
+        return;
+      }
+
+      const originalJson = res.json.bind(res);
+      res.json = function (body: unknown) {
+        const ttl = parseInt(process.env.IDEMPOTENCY_TTL_SECONDS ?? '86400', 10);
+        void cacheService.set(
+          cacheKey,
+          { status: res.statusCode, body, reqHash } satisfies CachedEntry,
+          ttl,
+        );
+        return originalJson(body);
+      };
+
+      next();
+    })();
+  };
+}

--- a/Backend/src/main.ts
+++ b/Backend/src/main.ts
@@ -10,6 +10,8 @@ import {
   csrfProtection,
 } from './common/middleware/csrf.middleware';
 import { compressionMiddleware } from './common/middleware/compression.middleware';
+import { idempotencyMiddleware } from './common/middleware/idempotency.middleware';
+import { CacheService } from './cache/cache.service';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -35,6 +37,10 @@ async function bootstrap() {
   app.use(csrfCookieParser);
   app.use(csrfProtection);
   app.use(csrfErrorHandler);
+
+  // Issue 104 — Idempotency-Key support for mutation endpoints.
+  const cacheService = app.get(CacheService);
+  app.use(idempotencyMiddleware(cacheService));
 
   // Validation
   app.useGlobalPipes(


### PR DESCRIPTION
## Summary

Implemented an idempotency-key middleware for mutation endpoints following industry patterns (Stripe, Square). It caches POST/PATCH/PUT responses and replays them for identical retries within a configurable TTL window.

### Changes

- Created `Backend/src/common/middleware/idempotency.middleware.ts` — middleware that:
  - Checks for `Idempotency-Key` header on POST/PATCH/PUT requests
  - Caches the response status + body keyed by the idempotency key
  - Replays the cached response on subsequent identical requests with `Idempotency-Replayed: true` header
  - Returns 422 when the same key is used with a different request body or path
  - Uses configurable TTL via `IDEMPOTENCY_TTL_SECONDS` env var (default 24h)
  - Passes through when no key is present (no overhead for non-idempotent calls)
- Created `idempotency.middleware.spec.ts` — 7 tests covering:
  - Passthrough when no header is present
  - Passthrough for GET requests
  - First POST caches, second identical POST replays with header
  - Body mismatch returns 422
  - Path mismatch returns 422
  - Configurable TTL
  - No caching for requests without the header
- Integrated into `main.ts` via `app.get(CacheService)` + `app.use()`
- Added `IDEMPOTENCY_TTL_SECONDS` to `.env.example`
- Verified linting
- Verified all existing tests continue to pass

Closes #104