### PR TITLE
test: add axe-core a11y checks to landing and map pages

### DIFF
--- a/Frontend/package-lock.json
+++ b/Frontend/package-lock.json
@@ -42,7 +42,8 @@
         "tailwindcss": "^4",
         "typescript": "^5",
         "vite-tsconfig-paths": "^6.1.1",
-        "vitest": "^4.1.9"
+        "vitest": "^4.1.9",
+        "vitest-axe": "^0.1.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -6470,8 +6471,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -9207,6 +9207,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -12495,6 +12502,37 @@
         "vite": {
           "optional": false
         }
+      }
+    },
+    "node_modules/vitest-axe": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/vitest-axe/-/vitest-axe-0.1.0.tgz",
+      "integrity": "sha512-jvtXxeQPg8R/2ANTY8QicA5pvvdRP4F0FsVUAHANJ46YCDASie/cuhlSzu0DGcLmZvGBSBNsNuK3HqfaeknyvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aria-query": "^5.0.0",
+        "axe-core": "^4.4.2",
+        "chalk": "^5.0.1",
+        "dom-accessibility-api": "^0.5.14",
+        "lodash-es": "^4.17.21",
+        "redent": "^3.0.0"
+      },
+      "peerDependencies": {
+        "vitest": ">=0.16.0"
+      }
+    },
+    "node_modules/vitest-axe/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/vitest/node_modules/picomatch": {

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -48,6 +48,7 @@
     "tailwindcss": "^4",
     "typescript": "^5",
     "vite-tsconfig-paths": "^6.1.1",
-    "vitest": "^4.1.9"
+    "vitest": "^4.1.9",
+    "vitest-axe": "^0.1.0"
   }
 }

--- a/Frontend/src/app/map/page.test.tsx
+++ b/Frontend/src/app/map/page.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import { describe, it, expect, vi } from 'vitest'
+import { axe } from 'vitest-axe'
 import MapPage from './page'
 
 vi.mock('@/components/map/MapLoader', () => ({
@@ -16,5 +17,14 @@ describe('Map Page', () => {
     const { container } = render(<MapPage />)
     const main = container.querySelector('main')
     expect(main).toHaveClass('h-screen', 'w-screen')
+  })
+
+  it('has no serious or critical accessibility violations', async () => {
+    const { container } = render(<MapPage />)
+    const results = await axe(container)
+    const seriousOrCritical = results.violations.filter(
+      (violation) => violation.impact === 'serious' || violation.impact === 'critical'
+    )
+    expect(seriousOrCritical).toHaveLength(0)
   })
 })

--- a/Frontend/src/app/page.test.tsx
+++ b/Frontend/src/app/page.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import { describe, it, expect, vi } from 'vitest'
+import { axe } from 'vitest-axe'
 import LandingPage from './page'
 
 vi.mock('@/components/landing/Features', () => ({
@@ -19,5 +20,14 @@ describe('LandingPage', () => {
   it('renders the footer', () => {
     render(<LandingPage />)
     expect(screen.getByText('Footer section')).toBeInTheDocument()
+  })
+
+  it('has no serious or critical accessibility violations', async () => {
+    const { container } = render(<LandingPage />)
+    const results = await axe(container)
+    const seriousOrCritical = results.violations.filter(
+      (violation) => violation.impact === 'serious' || violation.impact === 'critical'
+    )
+    expect(seriousOrCritical).toHaveLength(0)
   })
 })

--- a/Frontend/src/tests/setup.ts
+++ b/Frontend/src/tests/setup.ts
@@ -1,1 +1,5 @@
 import '@testing-library/jest-dom'
+import * as axeMatchers from 'vitest-axe/matchers'
+import { expect } from 'vitest'
+
+expect.extend(axeMatchers)


### PR DESCRIPTION
Closes #141

Adds automated accessibility checks to the landing and map pages using `vitest-axe`.

## Changes
- Added `vitest-axe` as a dev dependency.
- Wired up the `toHaveNoViolations`-style matchers in `src/tests/setup.ts`.
- Added an accessibility test to `src/app/page.test.tsx` and `src/app/map/page.test.tsx` that runs `axe()` against the rendered page and fails on any `serious` or `critical` violations.
- No CI workflow changes needed — the existing Frontend job already runs `npm run test`, so these checks run automatically as part of the existing pipeline.

## Testing
Ran `npm test` — all 72 tests pass (13 test files), including the 2 new accessibility checks. Both pages currently have zero serious/critical violations.