### PR TITLE
feat(infra): Add complete main.tf, variables.tf, outputs.tf for Terraform module

### DIFF
--- a/infrastructure/terraform/README.md
+++ b/infrastructure/terraform/README.md
@@ -1,19 +1,95 @@
 # Terraform Configurations
 
-Infrastructure as Code for cloud resource provisioning.
+Infrastructure as Code for VertexChain cloud resource provisioning.
 
 ## Overview
 
-Terraform modules for provisioning cloud infrastructure for VertexChain.
+Terraform modules for provisioning AWS infrastructure for VertexChain,
+a location-aware micro-messaging platform built on Stellar.
 
-## Contents
+## Module Structure
 
-- AWS/GCP/Azure resource definitions
-- Network configurations
-- Database provisioning
-- Storage buckets
-- Load balancers
+```
+infrastructure/terraform/
+├── main.tf            # Root module entry point
+├── variables.tf       # Root module input variables
+├── outputs.tf         # Root module outputs (ARNs for every resource)
+├── providers.tf       # Terraform and provider configuration
+├── modules/
+│   ├── network/       # VPC, subnets, gateways, NACLs, security groups
+│   ├── compute/       # EKS, ASG, ALB, launch templates, target groups
+│   └── data/          # RDS, ElastiCache, S3, backup vaults & plans
+├── envs/              # Per-environment tfvars files
+│   ├── terraform.tfvars.dev
+│   ├── terraform.tfvars.staging
+│   ├── terraform.tfvars.prod
+│   └── terraform.tfvars.example
+├── tests/             # Terratest integration tests
+│   └── test_helper.go
+└── archive/           # Previous flat .tf files (kept for reference)
+```
 
 ## Usage
 
-Run `terraform plan` and `terraform apply` to provision resources.
+```bash
+# Initialize Terraform
+terraform init
+
+# Select workspace
+terraform workspace select dev || terraform workspace new dev
+
+# Plan with environment-specific variables
+terraform plan -var-file=envs/terraform.tfvars.dev
+
+# Apply changes
+terraform apply -var-file=envs/terraform.tfvars.dev
+```
+
+## Workspace Strategy
+
+Per-environment state isolation is handled by workspaces. Each environment
+uses its own `tfvars` file while sharing the same root module:
+
+| Environment | Workspace | Variable file            |
+|-------------|-----------|--------------------------|
+| dev         | `dev`     | `envs/terraform.tfvars.dev` |
+| staging     | `staging` | `envs/terraform.tfvars.staging` |
+| prod        | `prod`    | `envs/terraform.tfvars.prod` |
+
+## Outputs
+
+All resource ARNs are surfaced through the root module's `outputs.tf`.
+Run `terraform output` to see the full list after an apply.
+
+```bash
+terraform output
+# vpc_id                  = "vpc-xxx"
+# alb_arn                 = "arn:aws:elasticloadbalancing:..."
+# rds_instance_arn        = "arn:aws:rds:..."
+# redis_replication_group_arn = "arn:aws:elasticache:..."
+# s3_uploads_bucket_arn   = "arn:aws:s3:::..."
+# eks_cluster_arn         = "arn:aws:eks:..."
+# waf_web_acl_arn         = "arn:aws:wafv2:..."
+# cloudfront_distribution_arn = "arn:aws:cloudfront:..."
+# ...and many more
+```
+
+## Migrating from the flat structure
+
+The previous flat `.tf` files (vpc.tf, rds.tf, etc.) have been refactored into
+the submodule structure above. The original files are preserved in the
+`archive/` directory for reference and should be removed once the new modular
+structure is validated.
+
+Before applying the new module structure to an existing deployment:
+
+1. Import existing resources into the new module state:
+   ```bash
+   terraform import module.network.aws_vpc.this vpc-xxx
+   terraform import module.data.aws_db_instance.postgres db-xxx
+   # ... etc.
+   ```
+
+2. Run `terraform plan` to verify no unexpected changes.
+
+3. Apply once all differences are reconciled.

--- a/infrastructure/terraform/archive/README.md
+++ b/infrastructure/terraform/archive/README.md
@@ -1,0 +1,24 @@
+# Archived Terraform files
+
+This directory contains the previous flat `.tf` files that were in the root
+`infrastructure/terraform/` directory before the module-based refactoring
+(see issue #164).
+
+## Why was this refactored?
+
+The old structure had 40+ `.tf` files in a single flat directory with no
+`main.tf` entry point, scattered variable declarations, duplicate resource
+definitions (e.g., `aws_security_group.alb` defined in both `alb.tf` and
+`security-groups.tf`), and no outputs for resource ARNs.
+
+The new structure:
+- **`main.tf`** — clear root module entry point
+- **`outputs.tf`** — ARNs for every created resource
+- **`variables.tf`** — consolidated variable declarations (no duplicates)
+- **`modules/`** — clean split into `network`, `compute`, and `data` submodules
+
+## Removal
+
+These archive files can be safely removed once the new modular structure has
+been validated with `terraform plan` against a live environment. They are kept
+only as a reference during the migration period.

--- a/infrastructure/terraform/archive/alarms.tf
+++ b/infrastructure/terraform/archive/alarms.tf
@@ -1,0 +1,35 @@
+resource "aws_cloudwatch_metric_alarm" "cpu_high" {
+  alarm_name          = "vertexchain-cpu-high"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/ECS"
+  period              = 300
+  statistic           = "Average"
+  threshold           = 80
+  alarm_actions       = [aws_sns_topic.vertexchain_alerts.arn]
+}
+
+resource "aws_cloudwatch_metric_alarm" "memory_high" {
+  alarm_name          = "vertexchain-memory-high"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "MemoryUtilization"
+  namespace           = "AWS/ECS"
+  period              = 300
+  statistic           = "Average"
+  threshold           = 80
+  alarm_actions       = [aws_sns_topic.vertexchain_alerts.arn]
+}
+
+resource "aws_cloudwatch_metric_alarm" "errors_high" {
+  alarm_name          = "vertexchain-errors-high"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "5XXError"
+  namespace           = "AWS/ApplicationELB"
+  period              = 60
+  statistic           = "Sum"
+  threshold           = 10
+  alarm_actions       = [aws_sns_topic.vertexchain_alerts.arn]
+}

--- a/infrastructure/terraform/archive/alb-listeners.tf
+++ b/infrastructure/terraform/archive/alb-listeners.tf
@@ -1,0 +1,32 @@
+variable "certificate_arn" {
+  description = "ACM certificate ARN for HTTPS"
+  type        = string
+}
+
+resource "aws_lb_listener" "https" {
+  load_balancer_arn = aws_lb.main.arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+  certificate_arn   = var.certificate_arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.app.arn
+  }
+}
+
+resource "aws_lb_listener" "http_redirect" {
+  load_balancer_arn = aws_lb.main.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}

--- a/infrastructure/terraform/archive/alb.tf
+++ b/infrastructure/terraform/archive/alb.tf
@@ -1,0 +1,46 @@
+resource "aws_lb" "main" {
+  name               = "${var.project_name}-${var.environment}-alb"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.alb.id]
+  subnets            = var.public_subnet_ids
+
+  enable_deletion_protection = var.environment == "production" ? true : false
+
+  tags = {
+    Environment = var.environment
+    Project     = var.project_name
+  }
+}
+
+resource "aws_security_group" "alb" {
+  name        = "${var.project_name}-${var.environment}-alb-sg"
+  description = "Security group for ALB"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Environment = var.environment
+    Project     = var.project_name
+  }
+}

--- a/infrastructure/terraform/archive/asg.tf
+++ b/infrastructure/terraform/archive/asg.tf
@@ -1,0 +1,27 @@
+resource "aws_autoscaling_group" "app" {
+  name                = "${var.project_name}-${var.environment}-asg"
+  min_size            = var.asg_min_size
+  max_size            = var.asg_max_size
+  desired_capacity    = var.asg_desired_size
+  vpc_zone_identifier = var.private_subnet_ids
+
+  launch_template {
+    id      = aws_launch_template.app.id
+    version = "$Latest"
+  }
+
+  health_check_type         = "ELB"
+  health_check_grace_period = 300
+
+  tag {
+    key                 = "Name"
+    value               = "${var.project_name}-${var.environment}-app"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "Environment"
+    value               = var.environment
+    propagate_at_launch = true
+  }
+}

--- a/infrastructure/terraform/archive/backup-plans.tf
+++ b/infrastructure/terraform/archive/backup-plans.tf
@@ -1,0 +1,44 @@
+# Weekly backup plan. Adds a higher frequency cold-storage tier on top
+# of the daily plan so we keep monthly snapshots for a full year without
+# paying hot-storage costs.
+#
+# `backup_retention_days` is declared in variables.tf; it controls the
+# DR-region copy retention, matching the primary tier so DR capacity
+# planning stays predictable.
+
+resource "aws_backup_plan" "weekly" {
+  name = "${var.project_name}-${var.environment}-weekly-plan"
+
+  rule {
+    rule_name         = "weekly_backup"
+    target_vault_name = aws_backup_vault.main.name
+    schedule          = "cron(0 3 ? * SUN *)"
+    start_window      = 60
+    completion_window = 360
+
+    lifecycle {
+      cold_storage_after = 30
+      delete_after       = 365
+    }
+
+    # Mirror the weekly snapshot into the DR-region vault so a single
+    # regional outage does not lose the last good monthly copy.
+    dynamic "copy_action" {
+      for_each = var.enable_cross_region_backup ? [1] : []
+      content {
+        destination_vault_arn = aws_backup_vault.dr[0].arn
+
+        lifecycle {
+          # Match the on-primary retention for consistency.
+          cold_storage_after = 30
+          delete_after       = var.backup_retention_days
+        }
+      }
+    }
+  }
+
+  tags = {
+    Environment = var.environment
+    Project     = var.project_name
+  }
+}

--- a/infrastructure/terraform/archive/backup-vaults.tf
+++ b/infrastructure/terraform/archive/backup-vaults.tf
@@ -1,0 +1,172 @@
+resource "aws_backup_vault" "main" {
+  name        = "${var.project_name}-${var.environment}-vault"
+  kms_key_arn = aws_kms_key.backup.arn
+
+  tags = {
+    Environment = var.environment
+    Project     = var.project_name
+  }
+}
+
+# Primary-region KMS key. The key policy permits the AWS Backup
+# service principal from THIS region to use the key, so the service can
+# perform daily backups of tagged resources.
+resource "aws_kms_key" "backup" {
+  description             = "${var.project_name} backup encryption key (primary region)"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowRootAccountFullAccess"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+        }
+        Action   = "kms:*"
+        Resource = "*"
+      },
+      {
+        Sid    = "AllowAWSBackupServiceUseKey"
+        Effect = "Allow"
+        Principal = {
+          Service = "backup.amazonaws.com"
+        }
+        Action = [
+          "kms:Decrypt",
+          "kms:Encrypt",
+          "kms:GenerateDataKey",
+          "kms:ReEncrypt*",
+          "kms:DescribeKey",
+          "kms:CreateGrant",
+          "kms:ListGrants",
+        ]
+        Resource = "*"
+        # Restrict to the primary region so backups are scoped correctly.
+        Condition = {
+          StringEquals = {
+            "aws:SourceRegion" = var.region
+          }
+        }
+      },
+    ]
+  })
+
+  tags = {
+    Environment = var.environment
+    Project     = var.project_name
+  }
+}
+
+# --------------------------------------------------------------------------- #
+# Disaster-recovery region mirror
+#
+# Created via the aliased `aws.dr` provider. The DR KMS key policy
+# explicitly grants the AWS Backup service principal from the PRIMARY
+# region permission to encrypt with it; this is required for the
+# cross-region copy_action inside aws_backup_plan to succeed, because
+# AWS Backup writes the replica using the source region's service
+# identity and the destination region's key for envelope encryption.
+# --------------------------------------------------------------------------- #
+data "aws_caller_identity" "current" {
+  count = var.enable_cross_region_backup ? 1 : 0
+}
+
+resource "aws_kms_key" "dr_backup" {
+  provider                = aws.dr
+  count                   = var.enable_cross_region_backup ? 1 : 0
+  description             = "${var.project_name} backup encryption key (DR region)"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowRootAccountFullAccess"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::${data.aws_caller_identity.current[0].account_id}:root"
+        }
+        Action   = "kms:*"
+        Resource = "*"
+      },
+      {
+        # Allow the AWS Backup service in the primary region to write
+        # cross-region copies into the DR vault using this key.
+        Sid    = "AllowAWSBackupCrossRegionCopy"
+        Effect = "Allow"
+        Principal = {
+          Service = "backup.amazonaws.com"
+        }
+        Action = [
+          "kms:Decrypt",
+          "kms:Encrypt",
+          "kms:GenerateDataKey",
+          "kms:ReEncrypt*",
+          "kms:DescribeKey",
+          "kms:CreateGrant",
+          "kms:ListGrants",
+        ]
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "aws:SourceRegion" = var.region
+          }
+        }
+      },
+    ]
+  })
+
+  tags = {
+    Environment = var.environment
+    Project     = var.project_name
+  }
+}
+
+resource "aws_backup_vault" "dr" {
+  # Count-gated so dev environments can opt out by setting
+  # var.enable_cross_region_backup = false; this avoids provisioning
+  # KMS keys / vaults in a region the workload isn't using.
+  count = var.enable_cross_region_backup ? 1 : 0
+
+  provider    = aws.dr
+  name        = "${var.project_name}-${var.environment}-dr-vault"
+  kms_key_arn = aws_kms_key.dr_backup[0].arn
+
+  # Vault access policy: allow the AWS Backup service principal from
+  # the source region to write recovery points into this vault. Without
+  # this, the copy_action in the source plan is denied silently.
+  access_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowAWSBackupCrossRegionWrites"
+        Effect = "Allow"
+        Principal = {
+          Service = "backup.amazonaws.com"
+        }
+        Action = [
+          "backup:CopyFromBackupVault",
+          "backup:DescribeBackupVault",
+          "backup:ListBackupVaultJobs",
+          "backup:ListRecoveryPointsByBackupVault",
+          "backup:PutBackupVaultAccessPolicy",
+        ]
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "aws:SourceRegion" = var.region
+          }
+        }
+      },
+    ]
+  })
+
+  tags = {
+    Environment = var.environment
+    Project     = var.project_name
+  }
+}

--- a/infrastructure/terraform/archive/backup.tf
+++ b/infrastructure/terraform/archive/backup.tf
@@ -1,0 +1,52 @@
+# Daily backup plan. Recovery points are written to the primary-region
+# vault, then copied to the DR-region vault via the `copy_action` block
+# below — giving us regional resilience without needing a separate
+# copy-jobs plan. The `dynamic` block lets us turn replication off in
+# dev/local environments by setting `enable_cross_region_backup=false`.
+
+resource "aws_backup_plan" "main" {
+  name = "${var.project_name}-${var.environment}-backup-plan"
+
+  rule {
+    rule_name         = "daily_backup"
+    target_vault_name = aws_backup_vault.main.name
+    schedule          = "cron(0 2 * * ? *)"
+    start_window      = 60
+    completion_window = 180
+
+    lifecycle {
+      delete_after = var.backup_retention_days
+    }
+
+    # Cross-region copy: any resource selected (by the `Backup=true`
+    # tag in aws_backup_selection below) is automatically mirrored to
+    # `aws_backup_vault.dr` after the primary backup completes.
+    dynamic "copy_action" {
+      for_each = var.enable_cross_region_backup ? [1] : []
+      content {
+        destination_vault_arn = aws_backup_vault.dr[0].arn
+
+        lifecycle {
+          delete_after = var.backup_retention_days
+        }
+      }
+    }
+  }
+
+  tags = {
+    Environment = var.environment
+    Project     = var.project_name
+  }
+}
+
+resource "aws_backup_selection" "main" {
+  name         = "${var.project_name}-${var.environment}-backup-selection"
+  plan_id      = aws_backup_plan.main.id
+  iam_role_arn = aws_iam_role.backup.arn
+
+  selection_tag {
+    type  = "STRINGEQUALS"
+    key   = "Backup"
+    value = "true"
+  }
+}

--- a/infrastructure/terraform/archive/cdn-origins.tf
+++ b/infrastructure/terraform/archive/cdn-origins.tf
@@ -1,0 +1,10 @@
+variable "api_domain" {
+  description = "API domain for CloudFront origin"
+  type        = string
+  default     = "api.vertexchain.io"
+}
+
+locals {
+  api_origin_id      = "API-backend"
+  frontend_origin_id = "S3-frontend"
+}

--- a/infrastructure/terraform/archive/cloudfront.tf
+++ b/infrastructure/terraform/archive/cloudfront.tf
@@ -1,0 +1,59 @@
+variable "domain_name" {
+  description = "Custom domain name for CloudFront"
+  type        = string
+  default     = "vertexchain.io"
+}
+
+resource "aws_cloudfront_distribution" "frontend" {
+  enabled             = true
+  is_ipv6_enabled     = true
+  default_root_object = "index.html"
+  aliases             = [var.domain_name]
+
+  origin {
+    domain_name = aws_s3_bucket.frontend.bucket_regional_domain_name
+    origin_id   = "S3-frontend"
+
+    s3_origin_config {
+      origin_access_identity = aws_cloudfront_origin_access_identity.frontend.cloudfront_access_identity_path
+    }
+  }
+
+  default_cache_behavior {
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    target_origin_id       = "S3-frontend"
+    viewer_protocol_policy = "redirect-to-https"
+    compress               = true
+
+    forwarded_values {
+      query_string = false
+      cookies { forward = "none" }
+    }
+
+    min_ttl     = 0
+    default_ttl = 3600
+    max_ttl     = 86400
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = aws_acm_certificate.frontend.arn
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.2_2021"
+  }
+
+  restrictions {
+    geo_restriction { restriction_type = "none" }
+  }
+
+  tags = { Environment = var.environment, Project = var.project_name }
+}
+
+resource "aws_cloudfront_origin_access_identity" "frontend" {
+  comment = "OAI for ${var.project_name} frontend"
+}
+
+resource "aws_s3_bucket" "frontend" {
+  bucket = "${var.project_name}-${var.environment}-frontend"
+  tags   = { Environment = var.environment, Project = var.project_name }
+}

--- a/infrastructure/terraform/archive/cloudwatch.tf
+++ b/infrastructure/terraform/archive/cloudwatch.tf
@@ -1,0 +1,21 @@
+resource "aws_cloudwatch_log_group" "vertexchain" {
+  name              = "/vertexchain/app"
+  retention_in_days = 30
+}
+
+resource "aws_cloudwatch_dashboard" "vertexchain" {
+  dashboard_name = "vertexchain-dashboard"
+  dashboard_body = jsonencode({
+    widgets = [
+      {
+        type = "metric"
+        properties = {
+          title   = "CPU Utilization"
+          metrics = [["AWS/ECS", "CPUUtilization", "ServiceName", "vertexchain"]]
+          period  = 300
+          stat    = "Average"
+        }
+      }
+    ]
+  })
+}

--- a/infrastructure/terraform/archive/db-parameter-groups.tf
+++ b/infrastructure/terraform/archive/db-parameter-groups.tf
@@ -1,0 +1,16 @@
+resource "aws_db_parameter_group" "postgres" {
+  name   = "${var.project_name}-${var.environment}-postgres-params"
+  family = "postgres15"
+
+  parameter {
+    name  = "log_connections"
+    value = "1"
+  }
+
+  parameter {
+    name  = "log_disconnections"
+    value = "1"
+  }
+
+  tags = { Environment = var.environment, Project = var.project_name }
+}

--- a/infrastructure/terraform/archive/db-security-groups.tf
+++ b/infrastructure/terraform/archive/db-security-groups.tf
@@ -1,0 +1,6 @@
+resource "aws_db_subnet_group" "postgres" {
+  name       = "${var.project_name}-${var.environment}-db-subnet-group"
+  subnet_ids = var.private_subnet_ids
+
+  tags = { Environment = var.environment, Project = var.project_name }
+}

--- a/infrastructure/terraform/archive/dns-records.tf
+++ b/infrastructure/terraform/archive/dns-records.tf
@@ -1,0 +1,15 @@
+resource "aws_route53_record" "root_a" {
+  zone_id = aws_route53_zone.vertexchain.zone_id
+  name    = "vertexchain.io"
+  type    = "A"
+  ttl     = 300
+  records = ["0.0.0.0"] # replace with actual ALB IP or use alias
+}
+
+resource "aws_route53_record" "api_cname" {
+  zone_id = aws_route53_zone.vertexchain.zone_id
+  name    = "api.vertexchain.io"
+  type    = "CNAME"
+  ttl     = 300
+  records = ["alb.vertexchain.io"]
+}

--- a/infrastructure/terraform/archive/eks-cluster.tf
+++ b/infrastructure/terraform/archive/eks-cluster.tf
@@ -1,0 +1,17 @@
+# Variable declarations have been moved to variables.tf
+
+resource "aws_eks_cluster" "main" {
+  name     = "${var.project_name}-${var.environment}"
+  role_arn = aws_iam_role.eks_cluster.arn
+  version  = "1.29"
+
+  vpc_config {
+    subnet_ids              = concat(var.private_subnet_ids, var.public_subnet_ids)
+    endpoint_private_access = true
+    endpoint_public_access  = true
+  }
+
+  depends_on = [aws_iam_role_policy_attachment.eks_cluster_policy]
+
+  tags = { Environment = var.environment, Project = var.project_name }
+}

--- a/infrastructure/terraform/archive/eks-iam.tf
+++ b/infrastructure/terraform/archive/eks-iam.tf
@@ -1,0 +1,45 @@
+resource "aws_iam_role" "eks_cluster" {
+  name = "${var.project_name}-${var.environment}-eks-cluster-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = { Service = "eks.amazonaws.com" }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "eks_cluster_policy" {
+  role       = aws_iam_role.eks_cluster.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
+}
+
+resource "aws_iam_role" "eks_nodes" {
+  name = "${var.project_name}-${var.environment}-eks-nodes-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = { Service = "ec2.amazonaws.com" }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "eks_worker_node_policy" {
+  role       = aws_iam_role.eks_nodes.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+}
+
+resource "aws_iam_role_policy_attachment" "eks_cni_policy" {
+  role       = aws_iam_role.eks_nodes.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+}
+
+resource "aws_iam_role_policy_attachment" "eks_ecr_policy" {
+  role       = aws_iam_role.eks_nodes.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+}

--- a/infrastructure/terraform/archive/eks-node-groups.tf
+++ b/infrastructure/terraform/archive/eks-node-groups.tf
@@ -1,0 +1,24 @@
+resource "aws_eks_node_group" "app" {
+  cluster_name    = aws_eks_cluster.main.name
+  node_group_name = "${var.project_name}-${var.environment}-nodes"
+  node_role_arn   = aws_iam_role.eks_nodes.arn
+  subnet_ids      = var.private_subnet_ids
+
+  instance_types = [var.eks_node_instance_type]
+
+  scaling_config {
+    desired_size = var.eks_desired_size
+    min_size     = var.eks_min_size
+    max_size     = var.eks_max_size
+  }
+
+  update_config { max_unavailable = 1 }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.eks_worker_node_policy,
+    aws_iam_role_policy_attachment.eks_cni_policy,
+    aws_iam_role_policy_attachment.eks_ecr_policy,
+  ]
+
+  tags = { Environment = var.environment, Project = var.project_name }
+}

--- a/infrastructure/terraform/archive/elasticache.tf
+++ b/infrastructure/terraform/archive/elasticache.tf
@@ -1,0 +1,44 @@
+resource "aws_elasticache_replication_group" "redis" {
+  replication_group_id = "${var.project_name}-${var.environment}-redis"
+  description          = "Redis cluster for ${var.project_name} ${var.environment}"
+
+  node_type                  = var.redis_node_type
+  num_cache_clusters         = var.redis_num_cache_nodes
+  parameter_group_name       = aws_elasticache_parameter_group.redis.name
+  subnet_group_name          = aws_elasticache_subnet_group.redis.name
+  security_group_ids         = [aws_security_group.redis.id]
+  port                       = 6379
+  at_rest_encryption_enabled = true
+  transit_encryption_enabled = true
+  automatic_failover_enabled = var.redis_num_cache_nodes > 1 ? true : false
+
+  tags = {
+    Environment = var.environment
+    Project     = var.project_name
+  }
+}
+
+resource "aws_security_group" "redis" {
+  name        = "${var.project_name}-${var.environment}-redis-sg"
+  description = "Security group for Redis cluster"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port   = 6379
+    to_port     = 6379
+    protocol    = "tcp"
+    cidr_blocks = [var.vpc_cidr]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Environment = var.environment
+    Project     = var.project_name
+  }
+}

--- a/infrastructure/terraform/archive/gateways.tf
+++ b/infrastructure/terraform/archive/gateways.tf
@@ -1,0 +1,15 @@
+resource "aws_internet_gateway" "vertexchain" {
+  vpc_id = aws_vpc.vertexchain.id
+  tags   = { Name = "vertexchain-igw" }
+}
+
+resource "aws_eip" "nat" {
+  domain = "vpc"
+}
+
+resource "aws_nat_gateway" "vertexchain" {
+  allocation_id = aws_eip.nat.id
+  subnet_id     = aws_subnet.public_a.id
+  tags          = { Name = "vertexchain-nat" }
+  depends_on    = [aws_internet_gateway.vertexchain]
+}

--- a/infrastructure/terraform/archive/health-checks.tf
+++ b/infrastructure/terraform/archive/health-checks.tf
@@ -1,0 +1,8 @@
+resource "aws_route53_health_check" "vertexchain_api" {
+  fqdn              = "api.vertexchain.io"
+  port              = 443
+  type              = "HTTPS"
+  resource_path     = "/health"
+  failure_threshold = 3
+  request_interval  = 30
+}

--- a/infrastructure/terraform/archive/iam-attachments.tf
+++ b/infrastructure/terraform/archive/iam-attachments.tf
@@ -1,0 +1,32 @@
+resource "aws_iam_role_policy_attachment" "eks_cluster_policy" {
+  role       = aws_iam_role.eks.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_basic" {
+  role       = aws_iam_role.lambda.name
+  policy_arn = aws_iam_policy.lambda_basic.arn
+}
+
+resource "aws_iam_role_policy_attachment" "ec2_ssm" {
+  role       = aws_iam_role.ec2.name
+  policy_arn = aws_iam_policy.ec2_ssm.arn
+}
+
+resource "aws_iam_role_policy_attachment" "backup_policy" {
+  role       = aws_iam_role.backup.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForBackup"
+}
+
+# `AWSBackupServiceRolePolicyForRestores` is the AWS-recommended
+# companion to AWSBackupServiceRolePolicyForBackup whenever a backup
+# plan contains a cross-region `copy_action`. Without it the plan
+# applies but cross-region copy jobs can fail with `AccessDenied` on
+# the destination-side actions that AWS Backup triggers when it
+# replicates. Attachments are conditional so legacy deployments that
+# don't enable cross-region replication don't carry unused permissions.
+resource "aws_iam_role_policy_attachment" "backup_restore_policy" {
+  count      = var.enable_cross_region_backup ? 1 : 0
+  role       = aws_iam_role.backup.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForRestores"
+}

--- a/infrastructure/terraform/archive/iam-policies.tf
+++ b/infrastructure/terraform/archive/iam-policies.tf
@@ -1,0 +1,52 @@
+resource "aws_iam_policy" "lambda_basic" {
+  name        = "${var.project_name}-${var.environment}-lambda-basic"
+  description = "Least privilege policy for Lambda functions"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ]
+        Resource = "arn:aws:logs:${var.region}:*:log-group:/aws/lambda/${var.project_name}-${var.environment}-*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ec2:CreateNetworkInterface",
+          "ec2:DescribeNetworkInterfaces",
+          "ec2:DeleteNetworkInterface"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+
+  tags = { Environment = var.environment, Project = var.project_name }
+}
+
+resource "aws_iam_policy" "ec2_ssm" {
+  name        = "${var.project_name}-${var.environment}-ec2-ssm"
+  description = "Allow EC2 instances to use SSM Session Manager"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "ssm:UpdateInstanceInformation",
+        "ssmmessages:CreateControlChannel",
+        "ssmmessages:CreateDataChannel",
+        "ssmmessages:OpenControlChannel",
+        "ssmmessages:OpenDataChannel"
+      ]
+      Resource = "*"
+    }]
+  })
+
+  tags = { Environment = var.environment, Project = var.project_name }
+}

--- a/infrastructure/terraform/archive/iam-roles.tf
+++ b/infrastructure/terraform/archive/iam-roles.tf
@@ -1,0 +1,59 @@
+resource "aws_iam_role" "eks" {
+  name = "${var.project_name}-${var.environment}-eks-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = { Service = "eks.amazonaws.com" }
+    }]
+  })
+
+  tags = { Environment = var.environment, Project = var.project_name }
+}
+
+resource "aws_iam_role" "ec2" {
+  name = "${var.project_name}-${var.environment}-ec2-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = { Service = "ec2.amazonaws.com" }
+    }]
+  })
+
+  tags = { Environment = var.environment, Project = var.project_name }
+}
+
+resource "aws_iam_role" "lambda" {
+  name = "${var.project_name}-${var.environment}-lambda-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = { Service = "lambda.amazonaws.com" }
+    }]
+  })
+
+  tags = { Environment = var.environment, Project = var.project_name }
+}
+
+resource "aws_iam_role" "backup" {
+  name = "${var.project_name}-${var.environment}-backup-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = { Service = "backup.amazonaws.com" }
+    }]
+  })
+
+  tags = { Environment = var.environment, Project = var.project_name }
+}

--- a/infrastructure/terraform/archive/launch-templates.tf
+++ b/infrastructure/terraform/archive/launch-templates.tf
@@ -1,0 +1,39 @@
+variable "ami_id" {
+  description = "AMI ID for EC2 instances"
+  type        = string
+}
+
+variable "instance_type" {
+  description = "EC2 instance type"
+  type        = string
+  default     = "t3.medium"
+}
+
+resource "aws_launch_template" "app" {
+  name_prefix   = "${var.project_name}-${var.environment}-"
+  image_id      = var.ami_id
+  instance_type = var.instance_type
+
+  vpc_security_group_ids = [aws_security_group.app.id]
+
+  iam_instance_profile {
+    name = aws_iam_instance_profile.app.name
+  }
+
+  monitoring {
+    enabled = true
+  }
+
+  tag_specifications {
+    resource_type = "instance"
+    tags = {
+      Environment = var.environment
+      Project     = var.project_name
+    }
+  }
+}
+
+resource "aws_iam_instance_profile" "app" {
+  name = "${var.project_name}-${var.environment}-instance-profile"
+  role = "${var.project_name}-${var.environment}-ec2-role"
+}

--- a/infrastructure/terraform/archive/nacls.tf
+++ b/infrastructure/terraform/archive/nacls.tf
@@ -1,0 +1,73 @@
+variable "vpc_cidr" {
+  description = "VPC CIDR block"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+resource "aws_network_acl" "public" {
+  vpc_id     = var.vpc_id
+  subnet_ids = var.public_subnet_ids
+
+  ingress {
+    rule_no    = 100
+    protocol   = "tcp"
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 80
+    to_port    = 80
+  }
+
+  ingress {
+    rule_no    = 110
+    protocol   = "tcp"
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 443
+    to_port    = 443
+  }
+
+  ingress {
+    rule_no    = 120
+    protocol   = "tcp"
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 1024
+    to_port    = 65535
+  }
+
+  egress {
+    rule_no    = 100
+    protocol   = "-1"
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 0
+    to_port    = 0
+  }
+
+  tags = { Environment = var.environment, Project = var.project_name }
+}
+
+resource "aws_network_acl" "private" {
+  vpc_id     = var.vpc_id
+  subnet_ids = var.private_subnet_ids
+
+  ingress {
+    rule_no    = 100
+    protocol   = "tcp"
+    action     = "allow"
+    cidr_block = var.vpc_cidr
+    from_port  = 0
+    to_port    = 65535
+  }
+
+  egress {
+    rule_no    = 100
+    protocol   = "-1"
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 0
+    to_port    = 0
+  }
+
+  tags = { Environment = var.environment, Project = var.project_name }
+}

--- a/infrastructure/terraform/archive/rds.tf
+++ b/infrastructure/terraform/archive/rds.tf
@@ -1,0 +1,25 @@
+# Variable declarations have been moved to variables.tf
+
+resource "aws_db_instance" "postgres" {
+  identifier        = "${var.project_name}-${var.environment}-postgres"
+  engine            = "postgres"
+  engine_version    = "15"
+  instance_class    = var.db_instance_class
+  allocated_storage = 20
+  storage_encrypted = true
+
+  db_name  = "vertexchain"
+  username = "vertexchain"
+  password = var.db_password
+
+  db_subnet_group_name   = aws_db_subnet_group.postgres.name
+  vpc_security_group_ids = [aws_security_group.db.id]
+  parameter_group_name   = aws_db_parameter_group.postgres.name
+
+  backup_retention_period   = 7
+  monitoring_interval       = 60
+  skip_final_snapshot       = false
+  final_snapshot_identifier = "${var.project_name}-${var.environment}-final"
+
+  tags = { Environment = var.environment, Project = var.project_name }
+}

--- a/infrastructure/terraform/archive/redis-parameters.tf
+++ b/infrastructure/terraform/archive/redis-parameters.tf
@@ -1,0 +1,26 @@
+variable "redis_node_type" {
+  description = "ElastiCache node type"
+  type        = string
+  default     = "cache.t3.micro"
+}
+
+variable "redis_num_cache_nodes" {
+  description = "Number of cache nodes"
+  type        = number
+  default     = 1
+}
+
+resource "aws_elasticache_parameter_group" "redis" {
+  name   = "${var.project_name}-${var.environment}-redis-params"
+  family = "redis7"
+
+  parameter {
+    name  = "maxmemory-policy"
+    value = "allkeys-lru"
+  }
+
+  tags = {
+    Environment = var.environment
+    Project     = var.project_name
+  }
+}

--- a/infrastructure/terraform/archive/redis-subnet-groups.tf
+++ b/infrastructure/terraform/archive/redis-subnet-groups.tf
@@ -1,0 +1,9 @@
+resource "aws_elasticache_subnet_group" "redis" {
+  name       = "${var.project_name}-${var.environment}-redis-subnet-group"
+  subnet_ids = var.private_subnet_ids
+
+  tags = {
+    Environment = var.environment
+    Project     = var.project_name
+  }
+}

--- a/infrastructure/terraform/archive/route53.tf
+++ b/infrastructure/terraform/archive/route53.tf
@@ -1,0 +1,3 @@
+resource "aws_route53_zone" "vertexchain" {
+  name = "vertexchain.io"
+}

--- a/infrastructure/terraform/archive/s3-buckets.tf
+++ b/infrastructure/terraform/archive/s3-buckets.tf
@@ -1,0 +1,35 @@
+# Variable declarations have been moved to variables.tf
+
+resource "aws_s3_bucket" "uploads" {
+  bucket = "${var.project_name}-${var.environment}-uploads"
+  tags   = { Environment = var.environment, Project = var.project_name }
+}
+
+resource "aws_s3_bucket_versioning" "uploads" {
+  bucket = aws_s3_bucket.uploads.id
+  versioning_configuration { status = "Enabled" }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "uploads" {
+  bucket = aws_s3_bucket.uploads.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket" "backups" {
+  bucket = "${var.project_name}-${var.environment}-backups"
+  tags   = { Environment = var.environment, Project = var.project_name }
+}
+
+resource "aws_s3_bucket_versioning" "backups" {
+  bucket = aws_s3_bucket.backups.id
+  versioning_configuration { status = "Enabled" }
+}
+
+resource "aws_s3_bucket" "logs" {
+  bucket = "${var.project_name}-${var.environment}-logs"
+  tags   = { Environment = var.environment, Project = var.project_name }
+}

--- a/infrastructure/terraform/archive/s3-lifecycle.tf
+++ b/infrastructure/terraform/archive/s3-lifecycle.tf
@@ -1,0 +1,31 @@
+resource "aws_s3_bucket_lifecycle_configuration" "uploads" {
+  bucket = aws_s3_bucket.uploads.id
+
+  rule {
+    id     = "transition-to-ia"
+    status = "Enabled"
+
+    transition {
+      days          = 30
+      storage_class = "STANDARD_IA"
+    }
+
+    transition {
+      days          = 90
+      storage_class = "GLACIER"
+    }
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "logs" {
+  bucket = aws_s3_bucket.logs.id
+
+  rule {
+    id     = "expire-logs"
+    status = "Enabled"
+
+    expiration {
+      days = 90
+    }
+  }
+}

--- a/infrastructure/terraform/archive/s3-policies.tf
+++ b/infrastructure/terraform/archive/s3-policies.tf
@@ -1,0 +1,23 @@
+resource "aws_s3_bucket_public_access_block" "uploads" {
+  bucket                  = aws_s3_bucket.uploads.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_public_access_block" "backups" {
+  bucket                  = aws_s3_bucket.backups.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_public_access_block" "logs" {
+  bucket                  = aws_s3_bucket.logs.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}

--- a/infrastructure/terraform/archive/scaling-policies.tf
+++ b/infrastructure/terraform/archive/scaling-policies.tf
@@ -1,0 +1,12 @@
+resource "aws_autoscaling_policy" "cpu_target" {
+  name                   = "${var.project_name}-${var.environment}-cpu-target"
+  autoscaling_group_name = aws_autoscaling_group.app.name
+  policy_type            = "TargetTrackingScaling"
+
+  target_tracking_configuration {
+    predefined_metric_specification {
+      predefined_metric_type = "ASGAverageCPUUtilization"
+    }
+    target_value = 70.0
+  }
+}

--- a/infrastructure/terraform/archive/secrets-manager.tf
+++ b/infrastructure/terraform/archive/secrets-manager.tf
@@ -1,0 +1,39 @@
+# Secrets Manager for centralized secrets storage
+resource "aws_secretsmanager_secret" "app_secret" {
+  name                    = "${var.app_name}-${var.environment}-secret"
+  description             = "Application secrets for ${var.environment}"
+  recovery_window_in_days = 7
+
+  tags = {
+    Environment = var.environment
+    ManagedBy   = "terraform"
+  }
+}
+
+resource "aws_secretsmanager_secret_version" "app_secret_version" {
+  secret_id = aws_secretsmanager_secret.app_secret.id
+  secret_string = jsonencode({
+    placeholder = "replace-with-real-secret"
+  })
+
+  lifecycle {
+    ignore_changes = [secret_string]
+  }
+}
+
+variable "app_name" {
+  description = "Application name"
+  type        = string
+  default     = "vertexchain"
+}
+
+variable "environment" {
+  description = "Deployment environment"
+  type        = string
+  default     = "dev"
+}
+
+output "secret_arn" {
+  description = "ARN of the application secret"
+  value       = aws_secretsmanager_secret.app_secret.arn
+}

--- a/infrastructure/terraform/archive/security-groups.tf
+++ b/infrastructure/terraform/archive/security-groups.tf
@@ -1,0 +1,77 @@
+variable "vpc_id" {
+  description = "VPC ID"
+  type        = string
+}
+
+resource "aws_security_group" "app" {
+  name        = "${var.project_name}-${var.environment}-app-sg"
+  description = "Security group for application servers"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port       = 3000
+    to_port         = 3000
+    protocol        = "tcp"
+    security_groups = [aws_security_group.alb.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = { Environment = var.environment, Project = var.project_name }
+}
+
+resource "aws_security_group" "alb" {
+  name        = "${var.project_name}-${var.environment}-alb-sg"
+  description = "Security group for ALB"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = { Environment = var.environment, Project = var.project_name }
+}
+
+resource "aws_security_group" "db" {
+  name        = "${var.project_name}-${var.environment}-db-sg"
+  description = "Security group for RDS"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port       = 5432
+    to_port         = 5432
+    protocol        = "tcp"
+    security_groups = [aws_security_group.app.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = { Environment = var.environment, Project = var.project_name }
+}

--- a/infrastructure/terraform/archive/sg-rules.tf
+++ b/infrastructure/terraform/archive/sg-rules.tf
@@ -1,0 +1,17 @@
+resource "aws_security_group_rule" "app_egress_db" {
+  type                     = "egress"
+  from_port                = 5432
+  to_port                  = 5432
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.app.id
+  source_security_group_id = aws_security_group.db.id
+}
+
+resource "aws_security_group_rule" "app_egress_redis" {
+  type              = "egress"
+  from_port         = 6379
+  to_port           = 6379
+  protocol          = "tcp"
+  security_group_id = aws_security_group.app.id
+  cidr_blocks       = [var.vpc_cidr]
+}

--- a/infrastructure/terraform/archive/sns-topics.tf
+++ b/infrastructure/terraform/archive/sns-topics.tf
@@ -1,0 +1,9 @@
+resource "aws_sns_topic" "vertexchain_alerts" {
+  name = "vertexchain-alerts"
+}
+
+resource "aws_sns_topic_subscription" "vertexchain_email" {
+  topic_arn = aws_sns_topic.vertexchain_alerts.arn
+  protocol  = "email"
+  endpoint  = "ops@vertexchain.io"
+}

--- a/infrastructure/terraform/archive/ssl-certificates.tf
+++ b/infrastructure/terraform/archive/ssl-certificates.tf
@@ -1,0 +1,14 @@
+resource "aws_acm_certificate" "frontend" {
+  domain_name               = var.domain_name
+  subject_alternative_names = ["*.${var.domain_name}"]
+  validation_method         = "DNS"
+
+  lifecycle { create_before_destroy = true }
+
+  tags = { Environment = var.environment, Project = var.project_name }
+}
+
+resource "aws_acm_certificate_validation" "frontend" {
+  certificate_arn         = aws_acm_certificate.frontend.arn
+  validation_record_fqdns = [for r in aws_acm_certificate.frontend.domain_validation_options : r.resource_record_name]
+}

--- a/infrastructure/terraform/archive/subnets.tf
+++ b/infrastructure/terraform/archive/subnets.tf
@@ -1,0 +1,29 @@
+resource "aws_subnet" "public_a" {
+  vpc_id                  = aws_vpc.vertexchain.id
+  cidr_block              = "10.0.1.0/24"
+  availability_zone       = "us-east-1a"
+  map_public_ip_on_launch = true
+  tags                    = { Name = "vertexchain-public-a" }
+}
+
+resource "aws_subnet" "public_b" {
+  vpc_id                  = aws_vpc.vertexchain.id
+  cidr_block              = "10.0.2.0/24"
+  availability_zone       = "us-east-1b"
+  map_public_ip_on_launch = true
+  tags                    = { Name = "vertexchain-public-b" }
+}
+
+resource "aws_subnet" "private_a" {
+  vpc_id            = aws_vpc.vertexchain.id
+  cidr_block        = "10.0.11.0/24"
+  availability_zone = "us-east-1a"
+  tags              = { Name = "vertexchain-private-a" }
+}
+
+resource "aws_subnet" "private_b" {
+  vpc_id            = aws_vpc.vertexchain.id
+  cidr_block        = "10.0.12.0/24"
+  availability_zone = "us-east-1b"
+  tags              = { Name = "vertexchain-private-b" }
+}

--- a/infrastructure/terraform/archive/tags.tf
+++ b/infrastructure/terraform/archive/tags.tf
@@ -1,0 +1,17 @@
+# Standard tag schema for cost tracking and resource management
+# Variable declarations have been moved to variables.tf
+
+locals {
+  common_tags = {
+    Project     = var.project_name
+    Environment = var.environment
+    CostCenter  = var.cost_center
+    Owner       = var.owner
+    ManagedBy   = "terraform"
+  }
+}
+
+output "common_tags" {
+  description = "Standard tags applied to all resources"
+  value       = local.common_tags
+}

--- a/infrastructure/terraform/archive/target-groups.tf
+++ b/infrastructure/terraform/archive/target-groups.tf
@@ -1,0 +1,20 @@
+resource "aws_lb_target_group" "app" {
+  name        = "${var.project_name}-${var.environment}-tg"
+  port        = 3000
+  protocol    = "HTTP"
+  vpc_id      = var.vpc_id
+  target_type = "ip"
+
+  health_check {
+    path                = "/health"
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+    interval            = 30
+    timeout             = 5
+  }
+
+  tags = {
+    Environment = var.environment
+    Project     = var.project_name
+  }
+}

--- a/infrastructure/terraform/archive/vpc.tf
+++ b/infrastructure/terraform/archive/vpc.tf
@@ -1,0 +1,9 @@
+resource "aws_vpc" "vertexchain" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = {
+    Name = "vertexchain-vpc"
+  }
+}

--- a/infrastructure/terraform/archive/waf.tf
+++ b/infrastructure/terraform/archive/waf.tf
@@ -1,0 +1,56 @@
+# WAF for application protection
+resource "aws_wafv2_web_acl" "app_waf" {
+  name  = "${var.app_name}-${var.environment}-waf"
+  scope = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+
+  rule {
+    name     = "AWSManagedRulesCommonRuleSet"
+    priority = 1
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesCommonRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "CommonRuleSetMetric"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "${var.app_name}-waf"
+    sampled_requests_enabled   = true
+  }
+
+  tags = {
+    Environment = var.environment
+    ManagedBy   = "terraform"
+  }
+}
+
+variable "app_name" {
+  type    = string
+  default = "vertexchain"
+}
+
+variable "environment" {
+  type    = string
+  default = "dev"
+}
+
+output "waf_arn" {
+  value = aws_wafv2_web_acl.app_waf.arn
+}

--- a/infrastructure/terraform/archive/workspaces.tf
+++ b/infrastructure/terraform/archive/workspaces.tf
@@ -1,0 +1,15 @@
+# Per-environment workspace configuration
+# Variable declarations have been moved to variables.tf
+#
+# When using per-env tfvars files the workspace name is used
+# only for state isolation; sizing values come from the tfvars
+# file chosen at plan/apply time rather than being hard-coded here.
+
+locals {
+  current_env = terraform.workspace
+}
+
+output "workspace_name" {
+  description = "Current Terraform workspace"
+  value       = terraform.workspace
+}

--- a/infrastructure/terraform/envs/terraform.tfvars.dev
+++ b/infrastructure/terraform/envs/terraform.tfvars.dev
@@ -7,16 +7,32 @@
 environment  = "dev"
 region       = "us-east-1"
 project_name = "vertexchain"
+domain_name  = "vertexchain.io"
+alert_email  = "ops@vertexchain.io"
 
-# Networking (fill in after VPC is created via bootstrap)
-vpc_id             = "vpc-REPLACE_DEV"
-vpc_cidr           = "10.0.0.0/16"
-private_subnet_ids = ["subnet-REPLACE_DEV_PRIVATE_1", "subnet-REPLACE_DEV_PRIVATE_2"]
-public_subnet_ids  = ["subnet-REPLACE_DEV_PUBLIC_1", "subnet-REPLACE_DEV_PUBLIC_2"]
+# Networking
+vpc_cidr             = "10.0.0.0/16"
+availability_zones   = ["us-east-1a", "us-east-1b"]
+public_subnet_cidrs  = ["10.0.1.0/24", "10.0.2.0/24"]
+private_subnet_cidrs = ["10.0.11.0/24", "10.0.12.0/24"]
 
 # Tags
 cost_center = "engineering"
 owner       = "platform-team"
+
+# Compute
+ami_id             = "ami-REPLACE_DEV"
+instance_type      = "t3.medium"
+eks_version        = "1.29"
+eks_node_instance_type = "t3.small"
+eks_desired_size   = 1
+eks_min_size       = 1
+eks_max_size       = 2
+
+# ASG
+asg_min_size      = 1
+asg_max_size      = 2
+asg_desired_size  = 1
 
 # RDS
 db_instance_class = "db.t3.micro"
@@ -25,13 +41,6 @@ db_instance_class = "db.t3.micro"
 redis_node_type       = "cache.t3.micro"
 redis_num_cache_nodes = 1
 
-# EKS node group
-eks_node_instance_type = "t3.small"
-eks_desired_size       = 1
-eks_min_size           = 1
-eks_max_size           = 2
-
-# ASG
-asg_min_size      = 1
-asg_max_size      = 2
-asg_desired_size  = 1
+# Backup
+enable_cross_region_backup = false
+backup_retention_days      = 7

--- a/infrastructure/terraform/envs/terraform.tfvars.example
+++ b/infrastructure/terraform/envs/terraform.tfvars.example
@@ -8,31 +8,40 @@
 environment  = "dev"           # dev | staging | prod
 region       = "us-east-1"
 project_name = "vertexchain"
+domain_name  = "vertexchain.io"
+alert_email  = "ops@vertexchain.io"
 
 # Networking
-vpc_id             = "vpc-xxxxxxxxxxxxxxxxx"
-vpc_cidr           = "10.0.0.0/16"
-private_subnet_ids = ["subnet-xxxxxxxxxxxxxxxxx", "subnet-xxxxxxxxxxxxxxxxx"]
-public_subnet_ids  = ["subnet-xxxxxxxxxxxxxxxxx", "subnet-xxxxxxxxxxxxxxxxx"]
+vpc_cidr             = "10.0.0.0/16"
+availability_zones   = ["us-east-1a", "us-east-1b"]
+public_subnet_cidrs  = ["10.0.1.0/24", "10.0.2.0/24"]
+private_subnet_cidrs = ["10.0.11.0/24", "10.0.12.0/24"]
 
 # Tags
 cost_center = "engineering"
 owner       = "platform-team"
 
-# RDS
-db_instance_class = "db.t3.micro"   # micro / small / medium per env
-
-# ElastiCache / Redis
-redis_node_type       = "cache.t3.micro"
-redis_num_cache_nodes = 1
-
-# EKS node group
+# Compute
+ami_id             = "ami-xxxxxxxxxxxxxxxxx"
+instance_type      = "t3.medium"
+eks_version        = "1.29"
 eks_node_instance_type = "t3.small"
-eks_desired_size       = 1
-eks_min_size           = 1
-eks_max_size           = 3
+eks_desired_size   = 1
+eks_min_size       = 1
+eks_max_size       = 3
 
 # ASG
 asg_min_size     = 1
 asg_max_size     = 3
 asg_desired_size = 1
+
+# RDS
+db_instance_class = "db.t3.micro"
+
+# ElastiCache / Redis
+redis_node_type       = "cache.t3.micro"
+redis_num_cache_nodes = 1
+
+# Backup
+enable_cross_region_backup = false          # set true for staging/prod
+backup_retention_days      = 30

--- a/infrastructure/terraform/envs/terraform.tfvars.prod
+++ b/infrastructure/terraform/envs/terraform.tfvars.prod
@@ -7,16 +7,32 @@
 environment  = "prod"
 region       = "us-east-1"
 project_name = "vertexchain"
+domain_name  = "vertexchain.io"
+alert_email  = "ops@vertexchain.io"
 
-# Networking (fill in after VPC is created via bootstrap)
-vpc_id             = "vpc-REPLACE_PROD"
-vpc_cidr           = "10.2.0.0/16"
-private_subnet_ids = ["subnet-REPLACE_PROD_PRIVATE_1", "subnet-REPLACE_PROD_PRIVATE_2", "subnet-REPLACE_PROD_PRIVATE_3"]
-public_subnet_ids  = ["subnet-REPLACE_PROD_PUBLIC_1", "subnet-REPLACE_PROD_PUBLIC_2", "subnet-REPLACE_PROD_PUBLIC_3"]
+# Networking
+vpc_cidr             = "10.2.0.0/16"
+availability_zones   = ["us-east-1a", "us-east-1b", "us-east-1c"]
+public_subnet_cidrs  = ["10.2.1.0/24", "10.2.2.0/24", "10.2.3.0/24"]
+private_subnet_cidrs = ["10.2.11.0/24", "10.2.12.0/24", "10.2.13.0/24"]
 
 # Tags
 cost_center = "engineering"
 owner       = "platform-team"
+
+# Compute
+ami_id             = "ami-REPLACE_PROD"
+instance_type      = "t3.large"
+eks_version        = "1.29"
+eks_node_instance_type = "t3.large"
+eks_desired_size   = 3
+eks_min_size       = 2
+eks_max_size       = 10
+
+# ASG
+asg_min_size     = 2
+asg_max_size     = 10
+asg_desired_size = 3
 
 # RDS
 db_instance_class = "db.t3.medium"
@@ -25,13 +41,6 @@ db_instance_class = "db.t3.medium"
 redis_node_type       = "cache.t3.medium"
 redis_num_cache_nodes = 2
 
-# EKS node group
-eks_node_instance_type = "t3.large"
-eks_desired_size       = 3
-eks_min_size           = 2
-eks_max_size           = 10
-
-# ASG
-asg_min_size     = 2
-asg_max_size     = 10
-asg_desired_size = 3
+# Backup
+enable_cross_region_backup = true
+backup_retention_days      = 30

--- a/infrastructure/terraform/envs/terraform.tfvars.staging
+++ b/infrastructure/terraform/envs/terraform.tfvars.staging
@@ -7,16 +7,32 @@
 environment  = "staging"
 region       = "us-east-1"
 project_name = "vertexchain"
+domain_name  = "vertexchain.io"
+alert_email  = "ops+staging@vertexchain.io"
 
-# Networking (fill in after VPC is created via bootstrap)
-vpc_id             = "vpc-REPLACE_STAGING"
-vpc_cidr           = "10.1.0.0/16"
-private_subnet_ids = ["subnet-REPLACE_STAGING_PRIVATE_1", "subnet-REPLACE_STAGING_PRIVATE_2"]
-public_subnet_ids  = ["subnet-REPLACE_STAGING_PUBLIC_1", "subnet-REPLACE_STAGING_PUBLIC_2"]
+# Networking
+vpc_cidr             = "10.1.0.0/16"
+availability_zones   = ["us-east-1a", "us-east-1b"]
+public_subnet_cidrs  = ["10.1.1.0/24", "10.1.2.0/24"]
+private_subnet_cidrs = ["10.1.11.0/24", "10.1.12.0/24"]
 
 # Tags
 cost_center = "engineering"
 owner       = "platform-team"
+
+# Compute
+ami_id             = "ami-REPLACE_STAGING"
+instance_type      = "t3.medium"
+eks_version        = "1.29"
+eks_node_instance_type = "t3.medium"
+eks_desired_size   = 2
+eks_min_size       = 1
+eks_max_size       = 4
+
+# ASG
+asg_min_size     = 1
+asg_max_size     = 4
+asg_desired_size = 2
 
 # RDS
 db_instance_class = "db.t3.small"
@@ -25,13 +41,6 @@ db_instance_class = "db.t3.small"
 redis_node_type       = "cache.t3.small"
 redis_num_cache_nodes = 1
 
-# EKS node group
-eks_node_instance_type = "t3.medium"
-eks_desired_size       = 2
-eks_min_size           = 1
-eks_max_size           = 4
-
-# ASG
-asg_min_size     = 1
-asg_max_size     = 4
-asg_desired_size = 2
+# Backup
+enable_cross_region_backup = true
+backup_retention_days      = 30

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -1,0 +1,495 @@
+# =============================================================================
+# Root module – VertexChain Terraform configuration
+#
+# Orchestrates the network, compute, and data submodules, then creates
+# cross-cutting resources such as IAM roles/policies, CloudFront, WAF,
+# Route53, ACM, CloudWatch, SNS, and Secrets Manager.
+# =============================================================================
+
+locals {
+  name_prefix = "${var.project_name}-${var.environment}"
+  common_tags = {
+    Project     = var.project_name
+    Environment = var.environment
+    CostCenter  = var.cost_center
+    Owner       = var.owner
+    ManagedBy   = "terraform"
+  }
+}
+
+# =============================================================================
+# Network submodule
+# =============================================================================
+module "network" {
+  source = "./modules/network"
+
+  name_prefix = local.name_prefix
+  vpc_cidr    = var.vpc_cidr
+
+  availability_zones  = var.availability_zones
+  public_subnet_cidrs = var.public_subnet_cidrs
+  private_subnet_cidrs = var.private_subnet_cidrs
+
+  tags = local.common_tags
+}
+
+# =============================================================================
+# Data submodule (RDS, ElastiCache, S3, backups)
+# =============================================================================
+module "data" {
+  source = "./modules/data"
+
+  providers = {
+    aws    = aws
+    aws.dr = aws.dr
+  }
+
+  name_prefix       = local.name_prefix
+  region            = var.region
+  private_subnet_ids = module.network.private_subnet_ids
+
+  security_group_db_id    = module.network.security_group_db_id
+  security_group_redis_id = module.network.security_group_redis_id
+
+  backup_iam_role_arn       = aws_iam_role.backup.arn
+  enable_cross_region_backup = var.enable_cross_region_backup
+
+  # RDS
+  db_instance_class = var.db_instance_class
+  db_password       = var.db_password
+
+  # Redis
+  redis_node_type       = var.redis_node_type
+  redis_num_cache_nodes = var.redis_num_cache_nodes
+
+  # Backup
+  backup_retention_days = var.backup_retention_days
+
+  tags = local.common_tags
+}
+
+# =============================================================================
+# Compute submodule (EKS, ASG, ALB)
+# =============================================================================
+module "compute" {
+  source = "./modules/compute"
+
+  name_prefix       = local.name_prefix
+  environment       = var.environment
+  vpc_id            = module.network.vpc_id
+  public_subnet_ids  = module.network.public_subnet_ids
+  private_subnet_ids = module.network.private_subnet_ids
+
+  security_group_alb_id = module.network.security_group_alb_id
+  security_group_app_id = module.network.security_group_app_id
+
+  certificate_arn   = aws_acm_certificate.frontend.arn
+  ami_id            = var.ami_id
+  instance_type     = var.instance_type
+  ec2_iam_role_name = aws_iam_role.ec2.name
+
+  # ASG
+  asg_min_size     = var.asg_min_size
+  asg_max_size     = var.asg_max_size
+  asg_desired_size = var.asg_desired_size
+
+  # EKS
+  eks_version             = var.eks_version
+  eks_node_instance_type  = var.eks_node_instance_type
+  eks_desired_size        = var.eks_desired_size
+  eks_min_size            = var.eks_min_size
+  eks_max_size            = var.eks_max_size
+
+  tags = local.common_tags
+}
+
+# =============================================================================
+# IAM Roles & Policies
+# =============================================================================
+
+# EC2 role (used by ASG launch template)
+resource "aws_iam_role" "ec2" {
+  name = "${local.name_prefix}-ec2-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = { Service = "ec2.amazonaws.com" }
+    }]
+  })
+
+  tags = local.common_tags
+}
+
+resource "aws_iam_policy" "ec2_ssm" {
+  name        = "${local.name_prefix}-ec2-ssm"
+  description = "Allow EC2 instances to use SSM Session Manager"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "ssm:UpdateInstanceInformation",
+        "ssmmessages:CreateControlChannel",
+        "ssmmessages:CreateDataChannel",
+        "ssmmessages:OpenControlChannel",
+        "ssmmessages:OpenDataChannel"
+      ]
+      Resource = "*"
+    }]
+  })
+
+  tags = local.common_tags
+}
+
+resource "aws_iam_role_policy_attachment" "ec2_ssm" {
+  role       = aws_iam_role.ec2.name
+  policy_arn = aws_iam_policy.ec2_ssm.arn
+}
+
+# Lambda role
+resource "aws_iam_role" "lambda" {
+  name = "${local.name_prefix}-lambda-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = { Service = "lambda.amazonaws.com" }
+    }]
+  })
+
+  tags = local.common_tags
+}
+
+resource "aws_iam_policy" "lambda_basic" {
+  name        = "${local.name_prefix}-lambda-basic"
+  description = "Least privilege policy for Lambda functions"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ]
+        Resource = "arn:aws:logs:${var.region}:*:log-group:/aws/lambda/${local.name_prefix}-*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ec2:CreateNetworkInterface",
+          "ec2:DescribeNetworkInterfaces",
+          "ec2:DeleteNetworkInterface"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+
+  tags = local.common_tags
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_basic" {
+  role       = aws_iam_role.lambda.name
+  policy_arn = aws_iam_policy.lambda_basic.arn
+}
+
+# Backup role
+resource "aws_iam_role" "backup" {
+  name = "${local.name_prefix}-backup-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = { Service = "backup.amazonaws.com" }
+    }]
+  })
+
+  tags = local.common_tags
+}
+
+resource "aws_iam_role_policy_attachment" "backup_policy" {
+  role       = aws_iam_role.backup.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForBackup"
+}
+
+resource "aws_iam_role_policy_attachment" "backup_restore_policy" {
+  count      = var.enable_cross_region_backup ? 1 : 0
+  role       = aws_iam_role.backup.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForRestores"
+}
+
+# =============================================================================
+# Route53 – DNS zone
+# =============================================================================
+resource "aws_route53_zone" "main" {
+  name = var.domain_name
+
+  tags = local.common_tags
+}
+
+resource "aws_route53_record" "root_a" {
+  zone_id = aws_route53_zone.main.zone_id
+  name    = var.domain_name
+  type    = "A"
+  ttl     = 300
+  records = ["0.0.0.0"] # FIXME: replace with actual ALB IP or use alias
+}
+
+resource "aws_route53_record" "api_cname" {
+  zone_id = aws_route53_zone.main.zone_id
+  name    = "api.${var.domain_name}"
+  type    = "CNAME"
+  ttl     = 300
+  records = ["alb.${var.domain_name}"]
+}
+
+resource "aws_route53_health_check" "api" {
+  fqdn              = "api.${var.domain_name}"
+  port              = 443
+  type              = "HTTPS"
+  resource_path     = "/health"
+  failure_threshold = 3
+  request_interval  = 30
+
+  tags = local.common_tags
+}
+
+# =============================================================================
+# ACM – SSL/TLS certificates
+# =============================================================================
+resource "aws_acm_certificate" "frontend" {
+  domain_name               = var.domain_name
+  subject_alternative_names = ["*.${var.domain_name}"]
+  validation_method         = "DNS"
+
+  lifecycle { create_before_destroy = true }
+
+  tags = local.common_tags
+}
+
+resource "aws_acm_certificate_validation" "frontend" {
+  certificate_arn         = aws_acm_certificate.frontend.arn
+  validation_record_fqdns = [for r in aws_acm_certificate.frontend.domain_validation_options : r.resource_record_name]
+}
+
+# =============================================================================
+# CloudFront – CDN for frontend assets
+# =============================================================================
+resource "aws_cloudfront_origin_access_identity" "frontend" {
+  comment = "OAI for ${local.name_prefix} frontend"
+}
+
+resource "aws_cloudfront_distribution" "frontend" {
+  enabled             = true
+  is_ipv6_enabled     = true
+  default_root_object = "index.html"
+  aliases             = [var.domain_name]
+
+  origin {
+    domain_name = module.data.s3_frontend_bucket_regional_domain_name
+    origin_id   = "S3-frontend"
+
+    s3_origin_config {
+      origin_access_identity = aws_cloudfront_origin_access_identity.frontend.cloudfront_access_identity_path
+    }
+  }
+
+  default_cache_behavior {
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    target_origin_id       = "S3-frontend"
+    viewer_protocol_policy = "redirect-to-https"
+    compress               = true
+
+    forwarded_values {
+      query_string = false
+      cookies { forward = "none" }
+    }
+
+    min_ttl     = 0
+    default_ttl = 3600
+    max_ttl     = 86400
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = aws_acm_certificate.frontend.arn
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.2_2021"
+  }
+
+  restrictions {
+    geo_restriction { restriction_type = "none" }
+  }
+
+  tags = local.common_tags
+}
+
+# =============================================================================
+# WAF – Web Application Firewall
+# =============================================================================
+resource "aws_wafv2_web_acl" "app" {
+  name  = "${local.name_prefix}-waf"
+  scope = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+
+  rule {
+    name     = "AWSManagedRulesCommonRuleSet"
+    priority = 1
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesCommonRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "CommonRuleSetMetric"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "${local.name_prefix}-waf"
+    sampled_requests_enabled   = true
+  }
+
+  tags = local.common_tags
+}
+
+# =============================================================================
+# WAF Association with ALB
+# =============================================================================
+resource "aws_wafv2_web_acl_association" "alb" {
+  resource_arn = module.compute.alb_arn
+  web_acl_arn  = aws_wafv2_web_acl.app.arn
+}
+
+# =============================================================================
+# CloudWatch – Logging & Monitoring
+# =============================================================================
+resource "aws_cloudwatch_log_group" "app" {
+  name              = "/vertexchain/app"
+  retention_in_days = 30
+
+  tags = local.common_tags
+}
+
+resource "aws_cloudwatch_dashboard" "main" {
+  dashboard_name = "${var.project_name}-dashboard"
+  dashboard_body = jsonencode({
+    widgets = [
+      {
+        type = "metric"
+        properties = {
+          title   = "CPU Utilization"
+          metrics = [["AWS/ECS", "CPUUtilization", "ServiceName", var.project_name]]
+          period  = 300
+          stat    = "Average"
+        }
+      }
+    ]
+  })
+}
+
+# =============================================================================
+# CloudWatch Alarms
+# =============================================================================
+resource "aws_cloudwatch_metric_alarm" "cpu_high" {
+  alarm_name          = "${var.project_name}-cpu-high"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/ECS"
+  period              = 300
+  statistic           = "Average"
+  threshold           = 80
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+
+  tags = local.common_tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "memory_high" {
+  alarm_name          = "${var.project_name}-memory-high"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "MemoryUtilization"
+  namespace           = "AWS/ECS"
+  period              = 300
+  statistic           = "Average"
+  threshold           = 80
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+
+  tags = local.common_tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "errors_high" {
+  alarm_name          = "${var.project_name}-errors-high"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "5XXError"
+  namespace           = "AWS/ApplicationELB"
+  period              = 60
+  statistic           = "Sum"
+  threshold           = 10
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+
+  tags = local.common_tags
+}
+
+# =============================================================================
+# SNS – Notifications
+# =============================================================================
+resource "aws_sns_topic" "alerts" {
+  name = "${var.project_name}-alerts"
+
+  tags = local.common_tags
+}
+
+resource "aws_sns_topic_subscription" "email" {
+  topic_arn = aws_sns_topic.alerts.arn
+  protocol  = "email"
+  endpoint  = var.alert_email
+}
+
+# =============================================================================
+# Secrets Manager
+# =============================================================================
+resource "aws_secretsmanager_secret" "app" {
+  name                    = "${local.name_prefix}-secret"
+  description             = "Application secrets for ${var.environment}"
+  recovery_window_in_days = 7
+
+  tags = local.common_tags
+}
+
+resource "aws_secretsmanager_secret_version" "app" {
+  secret_id = aws_secretsmanager_secret.app.id
+  secret_string = jsonencode({
+    placeholder = "replace-with-real-secret"
+  })
+
+  lifecycle {
+    ignore_changes = [secret_string]
+  }
+}

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -26,8 +26,8 @@ module "network" {
   name_prefix = local.name_prefix
   vpc_cidr    = var.vpc_cidr
 
-  availability_zones  = var.availability_zones
-  public_subnet_cidrs = var.public_subnet_cidrs
+  availability_zones   = var.availability_zones
+  public_subnet_cidrs  = var.public_subnet_cidrs
   private_subnet_cidrs = var.private_subnet_cidrs
 
   tags = local.common_tags
@@ -44,14 +44,14 @@ module "data" {
     aws.dr = aws.dr
   }
 
-  name_prefix       = local.name_prefix
-  region            = var.region
+  name_prefix        = local.name_prefix
+  region             = var.region
   private_subnet_ids = module.network.private_subnet_ids
 
   security_group_db_id    = module.network.security_group_db_id
   security_group_redis_id = module.network.security_group_redis_id
 
-  backup_iam_role_arn       = aws_iam_role.backup.arn
+  backup_iam_role_arn        = aws_iam_role.backup.arn
   enable_cross_region_backup = var.enable_cross_region_backup
 
   # RDS
@@ -74,9 +74,9 @@ module "data" {
 module "compute" {
   source = "./modules/compute"
 
-  name_prefix       = local.name_prefix
-  environment       = var.environment
-  vpc_id            = module.network.vpc_id
+  name_prefix        = local.name_prefix
+  environment        = var.environment
+  vpc_id             = module.network.vpc_id
   public_subnet_ids  = module.network.public_subnet_ids
   private_subnet_ids = module.network.private_subnet_ids
 
@@ -94,11 +94,11 @@ module "compute" {
   asg_desired_size = var.asg_desired_size
 
   # EKS
-  eks_version             = var.eks_version
-  eks_node_instance_type  = var.eks_node_instance_type
-  eks_desired_size        = var.eks_desired_size
-  eks_min_size            = var.eks_min_size
-  eks_max_size            = var.eks_max_size
+  eks_version            = var.eks_version
+  eks_node_instance_type = var.eks_node_instance_type
+  eks_desired_size       = var.eks_desired_size
+  eks_min_size           = var.eks_min_size
+  eks_max_size           = var.eks_max_size
 
   tags = local.common_tags
 }

--- a/infrastructure/terraform/modules/README.md
+++ b/infrastructure/terraform/modules/README.md
@@ -1,30 +1,81 @@
 # Terraform Modules
 
-Reusable Terraform modules for VertexChain infrastructure.
+Reusable Terraform modules for VertexChain infrastructure, refactored from a
+flat collection of `.tf` files into a clean, composable module structure.
 
 ## Structure
 
 ```
 modules/
-├── vpc/   — VPC, subnets, route tables, NAT gateway
-├── rds/   — RDS PostgreSQL instance with parameter groups
-└── eks/   — EKS cluster with managed node groups
+├── network/   — VPC, subnets, route tables, NAT gateway, NACLs, security groups
+├── compute/   — EKS cluster, node groups, ASG, ALB, launch templates, target groups
+└── data/      — RDS, ElastiCache, S3 buckets, backup vaults and plans
 ```
 
-## Usage
+## Module dependency graph
+
+```
+┌────────────────────────────────────────────┐
+│                  Root module               │
+│  (IAM, CloudFront, WAF, Route53, ACM,     │
+│   CloudWatch, SNS, Secrets Manager)        │
+└────┬────┬────┬─────────────────────────────┘
+     │    │    │
+     ▼    ▼    ▼
+  ┌────┐ ┌────┐ ┌────┐
+  │net-│ │data│ │comp│
+  │work│ │    │ │ute │
+  └──┬─┘ └─▲──┘ └─▲──┘
+     │     │      │
+     │     └──┬───┘ (references network outputs)
+     │        │
+     ▼────────┘
+  (all modules use root-level IAM roles)
+```
+
+## Root module usage
 
 ```hcl
-module "vpc" {
-  source = "./modules/vpc"
-  name   = "vertexchain-prod"
-  cidr   = "10.0.0.0/16"
+terraform {
+  required_version = ">= 1.5.0"
+
+  backend "s3" {
+    bucket = "vertexchain-terraform-state"
+    key    = "vertexchain/terraform.tfstate"
+    region = "us-east-1"
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
 }
 
-module "rds" {
-  source     = "./modules/rds"
-  vpc_id     = module.vpc.vpc_id
-  subnet_ids = module.vpc.private_subnet_ids
+provider "aws" {
+  region = var.region
+  default_tags {
+    tags = {
+      Project   = var.project_name
+      ManagedBy = "terraform"
+    }
+  }
 }
+```
+
+## Per-environment config
+
+```bash
+# Plan / apply with environment-specific variables
+terraform plan   -var-file=envs/terraform.tfvars.dev
+terraform apply  -var-file=envs/terraform.tfvars.dev
+
+terraform plan   -var-file=envs/terraform.tfvars.staging
+terraform apply  -var-file=envs/terraform.tfvars.staging
+
+terraform plan   -var-file=envs/terraform.tfvars.prod
+terraform apply  -var-file=envs/terraform.tfvars.prod
 ```
 
 ## Version Constraints
@@ -37,4 +88,5 @@ All modules require:
 
 Each module exposes typed input variables (`variables.tf`) and output values
 (`outputs.tf`). See the `README.md` inside each module directory for the full
-variable reference.
+variable reference. The root module's `outputs.tf` surfaces ARNs for every
+created resource.

--- a/infrastructure/terraform/modules/compute/main.tf
+++ b/infrastructure/terraform/modules/compute/main.tf
@@ -1,0 +1,247 @@
+# =============================================================================
+# Compute submodule – EKS, ASG, ALB, launch templates, target groups
+# =============================================================================
+
+# ---------------------------------------------------------------------------
+# Application Load Balancer
+# ---------------------------------------------------------------------------
+resource "aws_lb" "main" {
+  name               = "${var.name_prefix}-alb"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [var.security_group_alb_id]
+  subnets            = var.public_subnet_ids
+
+  enable_deletion_protection = var.environment == "prod" ? true : false
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-alb"
+  })
+}
+
+resource "aws_lb_target_group" "app" {
+  name        = "${var.name_prefix}-tg"
+  port        = 3000
+  protocol    = "HTTP"
+  vpc_id      = var.vpc_id
+  target_type = "ip"
+
+  health_check {
+    path                = "/health"
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+    interval            = 30
+    timeout             = 5
+  }
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-tg"
+  })
+}
+
+resource "aws_lb_listener" "https" {
+  load_balancer_arn = aws_lb.main.arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+  certificate_arn   = var.certificate_arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.app.arn
+  }
+}
+
+resource "aws_lb_listener" "http_redirect" {
+  load_balancer_arn = aws_lb.main.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Launch Template & IAM Instance Profile
+# ---------------------------------------------------------------------------
+resource "aws_iam_instance_profile" "app" {
+  name = "${var.name_prefix}-instance-profile"
+  role = var.ec2_iam_role_name
+}
+
+resource "aws_launch_template" "app" {
+  name_prefix   = "${var.name_prefix}-"
+  image_id      = var.ami_id
+  instance_type = var.instance_type
+
+  vpc_security_group_ids = [var.security_group_app_id]
+
+  iam_instance_profile {
+    name = aws_iam_instance_profile.app.name
+  }
+
+  monitoring {
+    enabled = true
+  }
+
+  tag_specifications {
+    resource_type = "instance"
+    tags = merge(var.tags, {
+      Name = "${var.name_prefix}-app"
+    })
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Auto Scaling Group
+# ---------------------------------------------------------------------------
+resource "aws_autoscaling_group" "app" {
+  name                = "${var.name_prefix}-asg"
+  min_size            = var.asg_min_size
+  max_size            = var.asg_max_size
+  desired_capacity    = var.asg_desired_size
+  vpc_zone_identifier = var.private_subnet_ids
+
+  launch_template {
+    id      = aws_launch_template.app.id
+    version = "$Latest"
+  }
+
+  health_check_type         = "ELB"
+  health_check_grace_period = 300
+
+  tag {
+    key                 = "Name"
+    value               = "${var.name_prefix}-app"
+    propagate_at_launch = true
+  }
+
+  dynamic "tag" {
+    for_each = var.tags
+    content {
+      key                 = tag.key
+      value               = tag.value
+      propagate_at_launch = true
+    }
+  }
+}
+
+resource "aws_autoscaling_policy" "cpu_target" {
+  name                   = "${var.name_prefix}-cpu-target"
+  autoscaling_group_name = aws_autoscaling_group.app.name
+  policy_type            = "TargetTrackingScaling"
+
+  target_tracking_configuration {
+    predefined_metric_specification {
+      predefined_metric_type = "ASGAverageCPUUtilization"
+    }
+    target_value = 70.0
+  }
+}
+
+# ---------------------------------------------------------------------------
+# EKS Cluster
+# ---------------------------------------------------------------------------
+resource "aws_iam_role" "eks_cluster" {
+  name = "${var.name_prefix}-eks-cluster-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = { Service = "eks.amazonaws.com" }
+    }]
+  })
+
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "eks_cluster_policy" {
+  role       = aws_iam_role.eks_cluster.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
+}
+
+resource "aws_eks_cluster" "main" {
+  name     = var.name_prefix
+  role_arn = aws_iam_role.eks_cluster.arn
+  version  = var.eks_version
+
+  vpc_config {
+    subnet_ids              = concat(var.private_subnet_ids, var.public_subnet_ids)
+    endpoint_private_access = true
+    endpoint_public_access  = true
+  }
+
+  depends_on = [aws_iam_role_policy_attachment.eks_cluster_policy]
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-eks"
+  })
+}
+
+# ---------------------------------------------------------------------------
+# EKS Node Group
+# ---------------------------------------------------------------------------
+resource "aws_iam_role" "eks_nodes" {
+  name = "${var.name_prefix}-eks-nodes-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = { Service = "ec2.amazonaws.com" }
+    }]
+  })
+
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "eks_worker_node_policy" {
+  role       = aws_iam_role.eks_nodes.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+}
+
+resource "aws_iam_role_policy_attachment" "eks_cni_policy" {
+  role       = aws_iam_role.eks_nodes.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+}
+
+resource "aws_iam_role_policy_attachment" "eks_ecr_policy" {
+  role       = aws_iam_role.eks_nodes.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+}
+
+resource "aws_eks_node_group" "app" {
+  cluster_name    = aws_eks_cluster.main.name
+  node_group_name = "${var.name_prefix}-nodes"
+  node_role_arn   = aws_iam_role.eks_nodes.arn
+  subnet_ids      = var.private_subnet_ids
+
+  instance_types = [var.eks_node_instance_type]
+
+  scaling_config {
+    desired_size = var.eks_desired_size
+    min_size     = var.eks_min_size
+    max_size     = var.eks_max_size
+  }
+
+  update_config { max_unavailable = 1 }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.eks_worker_node_policy,
+    aws_iam_role_policy_attachment.eks_cni_policy,
+    aws_iam_role_policy_attachment.eks_ecr_policy,
+  ]
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-eks-nodes"
+  })
+}

--- a/infrastructure/terraform/modules/compute/outputs.tf
+++ b/infrastructure/terraform/modules/compute/outputs.tf
@@ -1,0 +1,99 @@
+# =============================================================================
+# Compute submodule outputs
+# =============================================================================
+
+# --------------- ALB ---------------
+
+output "alb_arn" {
+  description = "ARN of the Application Load Balancer"
+  value       = aws_lb.main.arn
+}
+
+output "alb_dns_name" {
+  description = "DNS name of the ALB"
+  value       = aws_lb.main.dns_name
+}
+
+output "alb_zone_id" {
+  description = "Canonical hosted zone ID of the ALB"
+  value       = aws_lb.main.zone_id
+}
+
+output "target_group_arn" {
+  description = "ARN of the ALB target group"
+  value       = aws_lb_target_group.app.arn
+}
+
+output "listener_https_arn" {
+  description = "ARN of the HTTPS listener"
+  value       = aws_lb_listener.https.arn
+}
+
+output "listener_http_arn" {
+  description = "ARN of the HTTP redirect listener"
+  value       = aws_lb_listener.http_redirect.arn
+}
+
+# --------------- ASG ---------------
+
+output "asg_name" {
+  description = "Name of the Auto Scaling Group"
+  value       = aws_autoscaling_group.app.name
+}
+
+output "asg_arn" {
+  description = "ARN of the Auto Scaling Group"
+  value       = aws_autoscaling_group.app.arn
+}
+
+output "launch_template_id" {
+  description = "ID of the EC2 launch template"
+  value       = aws_launch_template.app.id
+}
+
+output "launch_template_arn" {
+  description = "ARN of the EC2 launch template"
+  value       = aws_launch_template.app.arn
+}
+
+output "iam_instance_profile_arn" {
+  description = "ARN of the IAM instance profile"
+  value       = aws_iam_instance_profile.app.arn
+}
+
+output "scaling_policy_arn" {
+  description = "ARN of the CPU target tracking scaling policy"
+  value       = aws_autoscaling_policy.cpu_target.arn
+}
+
+# --------------- EKS ---------------
+
+output "eks_cluster_arn" {
+  description = "ARN of the EKS cluster"
+  value       = aws_eks_cluster.main.arn
+}
+
+output "eks_cluster_name" {
+  description = "Name of the EKS cluster"
+  value       = aws_eks_cluster.main.name
+}
+
+output "eks_cluster_endpoint" {
+  description = "Endpoint for the EKS cluster API server"
+  value       = aws_eks_cluster.main.endpoint
+}
+
+output "eks_cluster_role_arn" {
+  description = "ARN of the EKS cluster IAM role"
+  value       = aws_iam_role.eks_cluster.arn
+}
+
+output "eks_node_role_arn" {
+  description = "ARN of the EKS node IAM role"
+  value       = aws_iam_role.eks_nodes.arn
+}
+
+output "eks_node_group_arn" {
+  description = "ARN of the EKS managed node group"
+  value       = aws_eks_node_group.app.arn
+}

--- a/infrastructure/terraform/modules/compute/variables.tf
+++ b/infrastructure/terraform/modules/compute/variables.tf
@@ -1,0 +1,119 @@
+# =============================================================================
+# Compute submodule input variables
+# =============================================================================
+
+variable "name_prefix" {
+  description = "Prefix applied to all resource names (e.g. vertexchain-dev)"
+  type        = string
+}
+
+variable "environment" {
+  description = "Deployment environment (dev | staging | prod)"
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "VPC ID"
+  type        = string
+}
+
+variable "public_subnet_ids" {
+  description = "List of public subnet IDs"
+  type        = list(string)
+}
+
+variable "private_subnet_ids" {
+  description = "List of private subnet IDs"
+  type        = list(string)
+}
+
+variable "security_group_alb_id" {
+  description = "ALB security group ID"
+  type        = string
+}
+
+variable "security_group_app_id" {
+  description = "App security group ID"
+  type        = string
+}
+
+variable "certificate_arn" {
+  description = "ACM certificate ARN for HTTPS listener"
+  type        = string
+}
+
+variable "ami_id" {
+  description = "AMI ID for EC2 launch template"
+  type        = string
+}
+
+variable "instance_type" {
+  description = "EC2 instance type for ASG launch template"
+  type        = string
+  default     = "t3.medium"
+}
+
+variable "ec2_iam_role_name" {
+  description = "Name of the IAM role for EC2 instances"
+  type        = string
+}
+
+# --------------- ASG ---------------
+
+variable "asg_min_size" {
+  description = "Minimum ASG capacity"
+  type        = number
+  default     = 1
+}
+
+variable "asg_max_size" {
+  description = "Maximum ASG capacity"
+  type        = number
+  default     = 3
+}
+
+variable "asg_desired_size" {
+  description = "Desired ASG capacity"
+  type        = number
+  default     = 1
+}
+
+# --------------- EKS ---------------
+
+variable "eks_version" {
+  description = "Kubernetes version for EKS cluster"
+  type        = string
+  default     = "1.29"
+}
+
+variable "eks_node_instance_type" {
+  description = "EC2 instance type for EKS managed node group"
+  type        = string
+  default     = "t3.small"
+}
+
+variable "eks_desired_size" {
+  description = "Desired number of EKS worker nodes"
+  type        = number
+  default     = 1
+}
+
+variable "eks_min_size" {
+  description = "Minimum number of EKS worker nodes"
+  type        = number
+  default     = 1
+}
+
+variable "eks_max_size" {
+  description = "Maximum number of EKS worker nodes"
+  type        = number
+  default     = 3
+}
+
+# --------------- Tags ---------------
+
+variable "tags" {
+  description = "Common tags applied to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/infrastructure/terraform/modules/data/main.tf
+++ b/infrastructure/terraform/modules/data/main.tf
@@ -1,0 +1,414 @@
+# =============================================================================
+# Data submodule – RDS, ElastiCache, S3, backups
+# =============================================================================
+
+# ---------------------------------------------------------------------------
+# RDS PostgreSQL
+# ---------------------------------------------------------------------------
+resource "aws_db_parameter_group" "postgres" {
+  name   = "${var.name_prefix}-postgres-params"
+  family = "postgres15"
+
+  parameter {
+    name  = "log_connections"
+    value = "1"
+  }
+
+  parameter {
+    name  = "log_disconnections"
+    value = "1"
+  }
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-postgres-params"
+  })
+}
+
+resource "aws_db_subnet_group" "postgres" {
+  name       = "${var.name_prefix}-db-subnet-group"
+  subnet_ids = var.private_subnet_ids
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-db-subnet-group"
+  })
+}
+
+resource "aws_db_instance" "postgres" {
+  identifier        = "${var.name_prefix}-postgres"
+  engine            = "postgres"
+  engine_version    = "15"
+  instance_class    = var.db_instance_class
+  allocated_storage = var.db_allocated_storage
+  storage_encrypted = true
+
+  db_name  = var.db_name
+  username = var.db_username
+  password = var.db_password
+
+  db_subnet_group_name   = aws_db_subnet_group.postgres.name
+  vpc_security_group_ids = [var.security_group_db_id]
+  parameter_group_name   = aws_db_parameter_group.postgres.name
+
+  backup_retention_period   = var.db_backup_retention_days
+  monitoring_interval       = 60
+  skip_final_snapshot       = false
+  final_snapshot_identifier = "${var.name_prefix}-final"
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-postgres"
+  })
+}
+
+# ---------------------------------------------------------------------------
+# ElastiCache Redis
+# ---------------------------------------------------------------------------
+resource "aws_elasticache_parameter_group" "redis" {
+  name   = "${var.name_prefix}-redis-params"
+  family = "redis7"
+
+  parameter {
+    name  = "maxmemory-policy"
+    value = "allkeys-lru"
+  }
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-redis-params"
+  })
+}
+
+resource "aws_elasticache_subnet_group" "redis" {
+  name       = "${var.name_prefix}-redis-subnet-group"
+  subnet_ids = var.private_subnet_ids
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-redis-subnet-group"
+  })
+}
+
+resource "aws_elasticache_replication_group" "redis" {
+  replication_group_id = "${var.name_prefix}-redis"
+  description          = "Redis cluster for ${var.name_prefix}"
+
+  node_type                  = var.redis_node_type
+  num_cache_clusters         = var.redis_num_cache_nodes
+  parameter_group_name       = aws_elasticache_parameter_group.redis.name
+  subnet_group_name          = aws_elasticache_subnet_group.redis.name
+  security_group_ids         = [var.security_group_redis_id]
+  port                       = 6379
+  at_rest_encryption_enabled = true
+  transit_encryption_enabled = true
+  automatic_failover_enabled = var.redis_num_cache_nodes > 1 ? true : false
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-redis"
+  })
+}
+
+# ---------------------------------------------------------------------------
+# S3 Buckets
+# ---------------------------------------------------------------------------
+
+# Uploads bucket
+resource "aws_s3_bucket" "uploads" {
+  bucket = "${var.name_prefix}-uploads"
+  tags   = merge(var.tags, { Name = "${var.name_prefix}-uploads" })
+}
+
+resource "aws_s3_bucket_versioning" "uploads" {
+  bucket = aws_s3_bucket.uploads.id
+  versioning_configuration { status = "Enabled" }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "uploads" {
+  bucket = aws_s3_bucket.uploads.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "uploads" {
+  bucket                  = aws_s3_bucket.uploads.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "uploads" {
+  bucket = aws_s3_bucket.uploads.id
+
+  rule {
+    id     = "transition-to-ia"
+    status = "Enabled"
+
+    transition {
+      days          = 30
+      storage_class = "STANDARD_IA"
+    }
+
+    transition {
+      days          = 90
+      storage_class = "GLACIER"
+    }
+  }
+}
+
+# Backups bucket
+resource "aws_s3_bucket" "backups" {
+  bucket = "${var.name_prefix}-backups"
+  tags   = merge(var.tags, { Name = "${var.name_prefix}-backups" })
+}
+
+resource "aws_s3_bucket_versioning" "backups" {
+  bucket = aws_s3_bucket.backups.id
+  versioning_configuration { status = "Enabled" }
+}
+
+resource "aws_s3_bucket_public_access_block" "backups" {
+  bucket                  = aws_s3_bucket.backups.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# Logs bucket
+resource "aws_s3_bucket" "logs" {
+  bucket = "${var.name_prefix}-logs"
+  tags   = merge(var.tags, { Name = "${var.name_prefix}-logs" })
+}
+
+resource "aws_s3_bucket_versioning" "logs" {
+  bucket = aws_s3_bucket.logs.id
+  versioning_configuration { status = "Enabled" }
+}
+
+resource "aws_s3_bucket_public_access_block" "logs" {
+  bucket                  = aws_s3_bucket.logs.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "logs" {
+  bucket = aws_s3_bucket.logs.id
+
+  rule {
+    id     = "expire-logs"
+    status = "Enabled"
+
+    expiration {
+      days = 90
+    }
+  }
+}
+
+# Frontend bucket (for CloudFront / S3 static hosting)
+resource "aws_s3_bucket" "frontend" {
+  bucket = "${var.name_prefix}-frontend"
+  tags   = merge(var.tags, { Name = "${var.name_prefix}-frontend" })
+}
+
+# ---------------------------------------------------------------------------
+# Backup – KMS keys, vaults, plans
+# ---------------------------------------------------------------------------
+data "aws_caller_identity" "current" {}
+
+resource "aws_kms_key" "backup" {
+  description             = "${var.name_prefix} backup encryption key (primary)"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowRootAccountFullAccess"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+        }
+        Action   = "kms:*"
+        Resource = "*"
+      },
+      {
+        Sid    = "AllowAWSBackupServiceUseKey"
+        Effect = "Allow"
+        Principal = {
+          Service = "backup.amazonaws.com"
+        }
+        Action = [
+          "kms:Decrypt", "kms:Encrypt", "kms:GenerateDataKey",
+          "kms:ReEncrypt*", "kms:DescribeKey", "kms:CreateGrant", "kms:ListGrants",
+        ]
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "aws:SourceRegion" = var.region
+          }
+        }
+      },
+    ]
+  })
+
+  tags = var.tags
+}
+
+resource "aws_backup_vault" "main" {
+  name        = "${var.name_prefix}-vault"
+  kms_key_arn = aws_kms_key.backup.arn
+
+  tags = merge(var.tags, { Name = "${var.name_prefix}-vault" })
+}
+
+resource "aws_kms_key" "dr_backup" {
+  count = var.enable_cross_region_backup ? 1 : 0
+
+  providers = { aws = aws.dr }
+
+  description             = "${var.name_prefix} backup encryption key (DR)"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowRootAccountFullAccess"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+        }
+        Action   = "kms:*"
+        Resource = "*"
+      },
+      {
+        Sid    = "AllowAWSBackupCrossRegionCopy"
+        Effect = "Allow"
+        Principal = {
+          Service = "backup.amazonaws.com"
+        }
+        Action = [
+          "kms:Decrypt", "kms:Encrypt", "kms:GenerateDataKey",
+          "kms:ReEncrypt*", "kms:DescribeKey", "kms:CreateGrant", "kms:ListGrants",
+        ]
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "aws:SourceRegion" = var.region
+          }
+        }
+      },
+    ]
+  })
+
+  tags = var.tags
+}
+
+resource "aws_backup_vault" "dr" {
+  count = var.enable_cross_region_backup ? 1 : 0
+
+  providers = { aws = aws.dr }
+
+  name        = "${var.name_prefix}-dr-vault"
+  kms_key_arn = aws_kms_key.dr_backup[0].arn
+
+  access_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowAWSBackupCrossRegionWrites"
+        Effect = "Allow"
+        Principal = {
+          Service = "backup.amazonaws.com"
+        }
+        Action = [
+          "backup:CopyFromBackupVault", "backup:DescribeBackupVault",
+          "backup:ListBackupVaultJobs", "backup:ListRecoveryPointsByBackupVault",
+          "backup:PutBackupVaultAccessPolicy",
+        ]
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "aws:SourceRegion" = var.region
+          }
+        }
+      },
+    ]
+  })
+
+  tags = merge(var.tags, { Name = "${var.name_prefix}-dr-vault" })
+}
+
+resource "aws_backup_plan" "daily" {
+  name = "${var.name_prefix}-daily-plan"
+
+  rule {
+    rule_name         = "daily_backup"
+    target_vault_name = aws_backup_vault.main.name
+    schedule          = "cron(0 2 * * ? *)"
+    start_window      = 60
+    completion_window = 180
+
+    lifecycle {
+      delete_after = var.backup_retention_days
+    }
+
+    dynamic "copy_action" {
+      for_each = var.enable_cross_region_backup ? [1] : []
+      content {
+        destination_vault_arn = aws_backup_vault.dr[0].arn
+        lifecycle {
+          delete_after = var.backup_retention_days
+        }
+      }
+    }
+  }
+
+  tags = var.tags
+}
+
+resource "aws_backup_plan" "weekly" {
+  name = "${var.name_prefix}-weekly-plan"
+
+  rule {
+    rule_name         = "weekly_backup"
+    target_vault_name = aws_backup_vault.main.name
+    schedule          = "cron(0 3 ? * SUN *)"
+    start_window      = 60
+    completion_window = 360
+
+    lifecycle {
+      cold_storage_after = 30
+      delete_after       = 365
+    }
+
+    dynamic "copy_action" {
+      for_each = var.enable_cross_region_backup ? [1] : []
+      content {
+        destination_vault_arn = aws_backup_vault.dr[0].arn
+        lifecycle {
+          cold_storage_after = 30
+          delete_after       = var.backup_retention_days
+        }
+      }
+    }
+  }
+
+  tags = var.tags
+}
+
+resource "aws_backup_selection" "main" {
+  name         = "${var.name_prefix}-backup-selection"
+  plan_id      = aws_backup_plan.daily.id
+  iam_role_arn = var.backup_iam_role_arn
+
+  selection_tag {
+    type  = "STRINGEQUALS"
+    key   = "Backup"
+    value = "true"
+  }
+}

--- a/infrastructure/terraform/modules/data/outputs.tf
+++ b/infrastructure/terraform/modules/data/outputs.tf
@@ -1,0 +1,166 @@
+# =============================================================================
+# Data submodule outputs
+# =============================================================================
+
+# --------------- RDS ---------------
+
+output "rds_instance_arn" {
+  description = "ARN of the RDS PostgreSQL instance"
+  value       = aws_db_instance.postgres.arn
+}
+
+output "rds_instance_id" {
+  description = "ID of the RDS PostgreSQL instance"
+  value       = aws_db_instance.postgres.id
+}
+
+output "rds_instance_endpoint" {
+  description = "Connection endpoint of the RDS instance"
+  value       = aws_db_instance.postgres.endpoint
+}
+
+output "rds_instance_address" {
+  description = "DNS address of the RDS instance"
+  value       = aws_db_instance.postgres.address
+}
+
+output "rds_port" {
+  description = "Port of the RDS instance"
+  value       = aws_db_instance.postgres.port
+}
+
+output "rds_parameter_group_arn" {
+  description = "ARN of the RDS parameter group"
+  value       = aws_db_parameter_group.postgres.arn
+}
+
+output "rds_subnet_group_arn" {
+  description = "ARN of the RDS subnet group"
+  value       = aws_db_subnet_group.postgres.arn
+}
+
+# --------------- ElastiCache / Redis ---------------
+
+output "redis_replication_group_arn" {
+  description = "ARN of the ElastiCache replication group"
+  value       = aws_elasticache_replication_group.redis.arn
+}
+
+output "redis_replication_group_id" {
+  description = "ID of the ElastiCache replication group"
+  value       = aws_elasticache_replication_group.redis.id
+}
+
+output "redis_primary_endpoint" {
+  description = "Primary endpoint address of the Redis cluster"
+  value       = aws_elasticache_replication_group.redis.primary_endpoint_address
+}
+
+output "redis_reader_endpoint" {
+  description = "Reader endpoint address of the Redis cluster"
+  value       = aws_elasticache_replication_group.redis.reader_endpoint_address
+}
+
+output "redis_port" {
+  description = "Port of the Redis cluster"
+  value       = aws_elasticache_replication_group.redis.port
+}
+
+output "redis_parameter_group_arn" {
+  description = "ARN of the Redis parameter group"
+  value       = aws_elasticache_parameter_group.redis.arn
+}
+
+output "redis_subnet_group_arn" {
+  description = "ARN of the Redis subnet group"
+  value       = aws_elasticache_subnet_group.redis.arn
+}
+
+# --------------- S3 ---------------
+
+output "s3_uploads_bucket_arn" {
+  description = "ARN of the uploads S3 bucket"
+  value       = aws_s3_bucket.uploads.arn
+}
+
+output "s3_uploads_bucket_id" {
+  description = "ID of the uploads S3 bucket"
+  value       = aws_s3_bucket.uploads.id
+}
+
+output "s3_backups_bucket_arn" {
+  description = "ARN of the backups S3 bucket"
+  value       = aws_s3_bucket.backups.arn
+}
+
+output "s3_backups_bucket_id" {
+  description = "ID of the backups S3 bucket"
+  value       = aws_s3_bucket.backups.id
+}
+
+output "s3_logs_bucket_arn" {
+  description = "ARN of the logs S3 bucket"
+  value       = aws_s3_bucket.logs.arn
+}
+
+output "s3_logs_bucket_id" {
+  description = "ID of the logs S3 bucket"
+  value       = aws_s3_bucket.logs.id
+}
+
+output "s3_frontend_bucket_arn" {
+  description = "ARN of the frontend S3 bucket"
+  value       = aws_s3_bucket.frontend.arn
+}
+
+output "s3_frontend_bucket_id" {
+  description = "ID of the frontend S3 bucket"
+  value       = aws_s3_bucket.frontend.id
+}
+
+output "s3_frontend_bucket_regional_domain_name" {
+  description = "Regional domain name of the frontend S3 bucket"
+  value       = aws_s3_bucket.frontend.bucket_regional_domain_name
+}
+
+# --------------- Backup ---------------
+
+output "backup_vault_arn" {
+  description = "ARN of the primary backup vault"
+  value       = aws_backup_vault.main.arn
+}
+
+output "backup_vault_name" {
+  description = "Name of the primary backup vault"
+  value       = aws_backup_vault.main.name
+}
+
+output "backup_kms_key_arn" {
+  description = "ARN of the backup KMS key"
+  value       = aws_kms_key.backup.arn
+}
+
+output "backup_dr_vault_arn" {
+  description = "ARN of the DR backup vault"
+  value       = var.enable_cross_region_backup ? aws_backup_vault.dr[0].arn : null
+}
+
+output "backup_dr_kms_key_arn" {
+  description = "ARN of the DR backup KMS key"
+  value       = var.enable_cross_region_backup ? aws_kms_key.dr_backup[0].arn : null
+}
+
+output "backup_daily_plan_arn" {
+  description = "ARN of the daily backup plan"
+  value       = aws_backup_plan.daily.arn
+}
+
+output "backup_weekly_plan_arn" {
+  description = "ARN of the weekly backup plan"
+  value       = aws_backup_plan.weekly.arn
+}
+
+output "backup_selection_id" {
+  description = "ID of the backup selection"
+  value       = aws_backup_selection.main.id
+}

--- a/infrastructure/terraform/modules/data/variables.tf
+++ b/infrastructure/terraform/modules/data/variables.tf
@@ -1,0 +1,108 @@
+# =============================================================================
+# Data submodule input variables
+# =============================================================================
+
+variable "name_prefix" {
+  description = "Prefix applied to all resource names (e.g. vertexchain-dev)"
+  type        = string
+}
+
+variable "region" {
+  description = "Primary AWS region"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "private_subnet_ids" {
+  description = "List of private subnet IDs"
+  type        = list(string)
+}
+
+variable "security_group_db_id" {
+  description = "RDS security group ID"
+  type        = string
+}
+
+variable "security_group_redis_id" {
+  description = "Redis security group ID"
+  type        = string
+}
+
+variable "backup_iam_role_arn" {
+  description = "ARN of the IAM role for AWS Backup"
+  type        = string
+}
+
+variable "enable_cross_region_backup" {
+  description = "Whether to replicate backups to the DR region"
+  type        = bool
+  default     = true
+}
+
+# --------------- RDS ---------------
+
+variable "db_instance_class" {
+  description = "RDS instance class"
+  type        = string
+  default     = "db.t3.micro"
+}
+
+variable "db_allocated_storage" {
+  description = "Allocated storage size in GB for RDS"
+  type        = number
+  default     = 20
+}
+
+variable "db_name" {
+  description = "Database name"
+  type        = string
+  default     = "vertexchain"
+}
+
+variable "db_username" {
+  description = "Database master username"
+  type        = string
+  default     = "vertexchain"
+}
+
+variable "db_password" {
+  description = "Database master password"
+  type        = string
+  sensitive   = true
+}
+
+variable "db_backup_retention_days" {
+  description = "Backup retention days for RDS"
+  type        = number
+  default     = 7
+}
+
+# --------------- ElastiCache / Redis ---------------
+
+variable "redis_node_type" {
+  description = "ElastiCache node type"
+  type        = string
+  default     = "cache.t3.micro"
+}
+
+variable "redis_num_cache_nodes" {
+  description = "Number of Redis cache nodes"
+  type        = number
+  default     = 1
+}
+
+# --------------- Backup ---------------
+
+variable "backup_retention_days" {
+  description = "Number of days to retain backups"
+  type        = number
+  default     = 30
+}
+
+# --------------- Tags ---------------
+
+variable "tags" {
+  description = "Common tags applied to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/infrastructure/terraform/modules/network/main.tf
+++ b/infrastructure/terraform/modules/network/main.tf
@@ -1,0 +1,340 @@
+# =============================================================================
+# Network submodule – VPC, subnets, gateways, route tables, NACLs, security groups
+# =============================================================================
+
+# ---------------------------------------------------------------------------
+# VPC
+# ---------------------------------------------------------------------------
+resource "aws_vpc" "this" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-vpc"
+  })
+}
+
+# ---------------------------------------------------------------------------
+# Subnets
+# ---------------------------------------------------------------------------
+resource "aws_subnet" "public" {
+  count = length(var.public_subnet_cidrs)
+
+  vpc_id                  = aws_vpc.this.id
+  cidr_block              = var.public_subnet_cidrs[count.index]
+  availability_zone       = var.availability_zones[count.index % length(var.availability_zones)]
+  map_public_ip_on_launch = true
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-public-${element(split("-", var.availability_zones[count.index % length(var.availability_zones)]), 1)}"
+    Tier = "public"
+  })
+}
+
+resource "aws_subnet" "private" {
+  count = length(var.private_subnet_cidrs)
+
+  vpc_id            = aws_vpc.this.id
+  cidr_block        = var.private_subnet_cidrs[count.index]
+  availability_zone = var.availability_zones[count.index % length(var.availability_zones)]
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-private-${element(split("-", var.availability_zones[count.index % length(var.availability_zones)]), 1)}"
+    Tier = "private"
+  })
+}
+
+# ---------------------------------------------------------------------------
+# Internet Gateway
+# ---------------------------------------------------------------------------
+resource "aws_internet_gateway" "this" {
+  vpc_id = aws_vpc.this.id
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-igw"
+  })
+}
+
+# ---------------------------------------------------------------------------
+# NAT Gateway
+# ---------------------------------------------------------------------------
+resource "aws_eip" "nat" {
+  domain = "vpc"
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-nat-eip"
+  })
+}
+
+resource "aws_nat_gateway" "this" {
+  allocation_id = aws_eip.nat.id
+  subnet_id     = aws_subnet.public[0].id
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-nat"
+  })
+
+  depends_on = [aws_internet_gateway.this]
+}
+
+# ---------------------------------------------------------------------------
+# Route Tables
+# ---------------------------------------------------------------------------
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.this.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.this.id
+  }
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-public-rt"
+    Tier = "public"
+  })
+}
+
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.this.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.this.id
+  }
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-private-rt"
+    Tier = "private"
+  })
+}
+
+resource "aws_route_table_association" "public" {
+  count = length(aws_subnet.public)
+
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table_association" "private" {
+  count = length(aws_subnet.private)
+
+  subnet_id      = aws_subnet.private[count.index].id
+  route_table_id = aws_route_table.private.id
+}
+
+# ---------------------------------------------------------------------------
+# Network ACLs
+# ---------------------------------------------------------------------------
+resource "aws_network_acl" "public" {
+  vpc_id     = aws_vpc.this.id
+  subnet_ids = aws_subnet.public[*].id
+
+  ingress {
+    rule_no    = 100
+    protocol   = "tcp"
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 80
+    to_port    = 80
+  }
+
+  ingress {
+    rule_no    = 110
+    protocol   = "tcp"
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 443
+    to_port    = 443
+  }
+
+  ingress {
+    rule_no    = 120
+    protocol   = "tcp"
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 1024
+    to_port    = 65535
+  }
+
+  egress {
+    rule_no    = 100
+    protocol   = "-1"
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 0
+    to_port    = 0
+  }
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-public-acl"
+    Tier = "public"
+  })
+}
+
+resource "aws_network_acl" "private" {
+  vpc_id     = aws_vpc.this.id
+  subnet_ids = aws_subnet.private[*].id
+
+  ingress {
+    rule_no    = 100
+    protocol   = "tcp"
+    action     = "allow"
+    cidr_block = var.vpc_cidr
+    from_port  = 0
+    to_port    = 65535
+  }
+
+  egress {
+    rule_no    = 100
+    protocol   = "-1"
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 0
+    to_port    = 0
+  }
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-private-acl"
+    Tier = "private"
+  })
+}
+
+# ---------------------------------------------------------------------------
+# Security Groups
+# ---------------------------------------------------------------------------
+
+# ALB – accepts HTTP/HTTPS from the internet
+resource "aws_security_group" "alb" {
+  name        = "${var.name_prefix}-alb-sg"
+  description = "Security group for Application Load Balancer"
+  vpc_id      = aws_vpc.this.id
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-alb-sg"
+  })
+}
+
+# Application – accepts traffic from ALB only
+resource "aws_security_group" "app" {
+  name        = "${var.name_prefix}-app-sg"
+  description = "Security group for application servers"
+  vpc_id      = aws_vpc.this.id
+
+  ingress {
+    from_port       = 3000
+    to_port         = 3000
+    protocol        = "tcp"
+    security_groups = [aws_security_group.alb.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-app-sg"
+  })
+}
+
+# Database – accepts PostgreSQL from app SG
+resource "aws_security_group" "db" {
+  name        = "${var.name_prefix}-db-sg"
+  description = "Security group for RDS PostgreSQL"
+  vpc_id      = aws_vpc.this.id
+
+  ingress {
+    from_port       = 5432
+    to_port         = 5432
+    protocol        = "tcp"
+    security_groups = [aws_security_group.app.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-db-sg"
+  })
+}
+
+# Redis – accepts Redis traffic from app SG and VPC CIDR
+resource "aws_security_group" "redis" {
+  name        = "${var.name_prefix}-redis-sg"
+  description = "Security group for ElastiCache Redis"
+  vpc_id      = aws_vpc.this.id
+
+  ingress {
+    from_port       = 6379
+    to_port         = 6379
+    protocol        = "tcp"
+    security_groups = [aws_security_group.app.id]
+  }
+
+  ingress {
+    from_port   = 6379
+    to_port     = 6379
+    protocol    = "tcp"
+    cidr_blocks = [var.vpc_cidr]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-redis-sg"
+  })
+}
+
+# ---------------------------------------------------------------------------
+# Security group rules (cross-SG references)
+# ---------------------------------------------------------------------------
+resource "aws_security_group_rule" "app_egress_db" {
+  type                     = "egress"
+  from_port                = 5432
+  to_port                  = 5432
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.app.id
+  source_security_group_id = aws_security_group.db.id
+}
+
+resource "aws_security_group_rule" "app_egress_redis" {
+  type              = "egress"
+  from_port         = 6379
+  to_port           = 6379
+  protocol          = "tcp"
+  security_group_id = aws_security_group.app.id
+  cidr_blocks       = [var.vpc_cidr]
+}

--- a/infrastructure/terraform/modules/network/outputs.tf
+++ b/infrastructure/terraform/modules/network/outputs.tf
@@ -1,0 +1,103 @@
+# =============================================================================
+# Network submodule outputs
+# =============================================================================
+
+output "vpc_id" {
+  description = "The ID of the VPC"
+  value       = aws_vpc.this.id
+}
+
+output "vpc_cidr" {
+  description = "The CIDR block of the VPC"
+  value       = aws_vpc.this.cidr_block
+}
+
+output "public_subnet_ids" {
+  description = "List of public subnet IDs"
+  value       = aws_subnet.public[*].id
+}
+
+output "private_subnet_ids" {
+  description = "List of private subnet IDs"
+  value       = aws_subnet.private[*].id
+}
+
+output "public_subnet_arns" {
+  description = "List of public subnet ARNs"
+  value       = aws_subnet.public[*].arn
+}
+
+output "private_subnet_arns" {
+  description = "List of private subnet ARNs"
+  value       = aws_subnet.private[*].arn
+}
+
+output "internet_gateway_id" {
+  description = "The ID of the Internet Gateway"
+  value       = aws_internet_gateway.this.id
+}
+
+output "nat_gateway_id" {
+  description = "The ID of the NAT Gateway"
+  value       = aws_nat_gateway.this.id
+}
+
+output "nat_eip_id" {
+  description = "The ID of the Elastic IP for NAT"
+  value       = aws_eip.nat.id
+}
+
+output "nat_eip_public_ip" {
+  description = "The public IP of the NAT Gateway EIP"
+  value       = aws_eip.nat.public_ip
+}
+
+output "security_group_alb_id" {
+  description = "The ID of the ALB security group"
+  value       = aws_security_group.alb.id
+}
+
+output "security_group_alb_arn" {
+  description = "The ARN of the ALB security group"
+  value       = aws_security_group.alb.arn
+}
+
+output "security_group_app_id" {
+  description = "The ID of the App security group"
+  value       = aws_security_group.app.id
+}
+
+output "security_group_app_arn" {
+  description = "The ARN of the App security group"
+  value       = aws_security_group.app.arn
+}
+
+output "security_group_db_id" {
+  description = "The ID of the DB security group"
+  value       = aws_security_group.db.id
+}
+
+output "security_group_db_arn" {
+  description = "The ARN of the DB security group"
+  value       = aws_security_group.db.arn
+}
+
+output "security_group_redis_id" {
+  description = "The ID of the Redis security group"
+  value       = aws_security_group.redis.id
+}
+
+output "security_group_redis_arn" {
+  description = "The ARN of the Redis security group"
+  value       = aws_security_group.redis.arn
+}
+
+output "public_route_table_id" {
+  description = "The ID of the public route table"
+  value       = aws_route_table.public.id
+}
+
+output "private_route_table_id" {
+  description = "The ID of the private route table"
+  value       = aws_route_table.private.id
+}

--- a/infrastructure/terraform/modules/network/variables.tf
+++ b/infrastructure/terraform/modules/network/variables.tf
@@ -1,0 +1,34 @@
+# =============================================================================
+# Network submodule input variables
+# =============================================================================
+
+variable "name_prefix" {
+  description = "Prefix applied to all resource names (e.g. vertexchain-dev)"
+  type        = string
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC"
+  type        = string
+}
+
+variable "availability_zones" {
+  description = "List of availability zones to use"
+  type        = list(string)
+}
+
+variable "public_subnet_cidrs" {
+  description = "CIDR blocks for public subnets"
+  type        = list(string)
+}
+
+variable "private_subnet_cidrs" {
+  description = "CIDR blocks for private subnets"
+  type        = list(string)
+}
+
+variable "tags" {
+  description = "Common tags applied to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/infrastructure/terraform/outputs.tf
+++ b/infrastructure/terraform/outputs.tf
@@ -1,0 +1,442 @@
+# =============================================================================
+# Root module outputs – surfaces ARNs and attributes of every created resource
+# =============================================================================
+
+# --------------- Network ---------------
+
+output "vpc_id" {
+  description = "The ID of the VPC"
+  value       = module.network.vpc_id
+}
+
+output "vpc_cidr" {
+  description = "The CIDR block of the VPC"
+  value       = module.network.vpc_cidr
+}
+
+output "public_subnet_ids" {
+  description = "List of public subnet IDs"
+  value       = module.network.public_subnet_ids
+}
+
+output "private_subnet_ids" {
+  description = "List of private subnet IDs"
+  value       = module.network.private_subnet_ids
+}
+
+output "public_subnet_arns" {
+  description = "List of public subnet ARNs"
+  value       = module.network.public_subnet_arns
+}
+
+output "private_subnet_arns" {
+  description = "List of private subnet ARNs"
+  value       = module.network.private_subnet_arns
+}
+
+output "internet_gateway_id" {
+  description = "The ID of the Internet Gateway"
+  value       = module.network.internet_gateway_id
+}
+
+output "nat_gateway_id" {
+  description = "The ID of the NAT Gateway"
+  value       = module.network.nat_gateway_id
+}
+
+output "nat_eip_id" {
+  description = "The ID of the NAT Elastic IP"
+  value       = module.network.nat_eip_id
+}
+
+output "nat_eip_public_ip" {
+  description = "The public IP of the NAT Gateway"
+  value       = module.network.nat_eip_public_ip
+}
+
+output "security_group_alb_id" {
+  description = "The ID of the ALB security group"
+  value       = module.network.security_group_alb_id
+}
+
+output "security_group_alb_arn" {
+  description = "The ARN of the ALB security group"
+  value       = module.network.security_group_alb_arn
+}
+
+output "security_group_app_id" {
+  description = "The ID of the App security group"
+  value       = module.network.security_group_app_id
+}
+
+output "security_group_app_arn" {
+  description = "The ARN of the App security group"
+  value       = module.network.security_group_app_arn
+}
+
+output "security_group_db_id" {
+  description = "The ID of the DB security group"
+  value       = module.network.security_group_db_id
+}
+
+output "security_group_db_arn" {
+  description = "The ARN of the DB security group"
+  value       = module.network.security_group_db_arn
+}
+
+output "security_group_redis_id" {
+  description = "The ID of the Redis security group"
+  value       = module.network.security_group_redis_id
+}
+
+output "security_group_redis_arn" {
+  description = "The ARN of the Redis security group"
+  value       = module.network.security_group_redis_arn
+}
+
+output "public_route_table_id" {
+  description = "The ID of the public route table"
+  value       = module.network.public_route_table_id
+}
+
+output "private_route_table_id" {
+  description = "The ID of the private route table"
+  value       = module.network.private_route_table_id
+}
+
+# --------------- Compute ---------------
+
+output "alb_arn" {
+  description = "ARN of the Application Load Balancer"
+  value       = module.compute.alb_arn
+}
+
+output "alb_dns_name" {
+  description = "DNS name of the ALB"
+  value       = module.compute.alb_dns_name
+}
+
+output "alb_zone_id" {
+  description = "Canonical hosted zone ID of the ALB"
+  value       = module.compute.alb_zone_id
+}
+
+output "target_group_arn" {
+  description = "ARN of the ALB target group"
+  value       = module.compute.target_group_arn
+}
+
+output "listener_https_arn" {
+  description = "ARN of the HTTPS listener"
+  value       = module.compute.listener_https_arn
+}
+
+output "asg_name" {
+  description = "Name of the Auto Scaling Group"
+  value       = module.compute.asg_name
+}
+
+output "asg_arn" {
+  description = "ARN of the Auto Scaling Group"
+  value       = module.compute.asg_arn
+}
+
+output "launch_template_id" {
+  description = "ID of the EC2 launch template"
+  value       = module.compute.launch_template_id
+}
+
+output "launch_template_arn" {
+  description = "ARN of the EC2 launch template"
+  value       = module.compute.launch_template_arn
+}
+
+output "iam_instance_profile_arn" {
+  description = "ARN of the IAM instance profile"
+  value       = module.compute.iam_instance_profile_arn
+}
+
+output "scaling_policy_arn" {
+  description = "ARN of the CPU scaling policy"
+  value       = module.compute.scaling_policy_arn
+}
+
+output "eks_cluster_arn" {
+  description = "ARN of the EKS cluster"
+  value       = module.compute.eks_cluster_arn
+}
+
+output "eks_cluster_name" {
+  description = "Name of the EKS cluster"
+  value       = module.compute.eks_cluster_name
+}
+
+output "eks_cluster_endpoint" {
+  description = "Endpoint of the EKS cluster"
+  value       = module.compute.eks_cluster_endpoint
+}
+
+output "eks_cluster_role_arn" {
+  description = "ARN of the EKS cluster IAM role"
+  value       = module.compute.eks_cluster_role_arn
+}
+
+output "eks_node_role_arn" {
+  description = "ARN of the EKS node IAM role"
+  value       = module.compute.eks_node_role_arn
+}
+
+output "eks_node_group_arn" {
+  description = "ARN of the EKS node group"
+  value       = module.compute.eks_node_group_arn
+}
+
+# --------------- Data ---------------
+
+output "rds_instance_arn" {
+  description = "ARN of the RDS PostgreSQL instance"
+  value       = module.data.rds_instance_arn
+}
+
+output "rds_instance_id" {
+  description = "ID of the RDS instance"
+  value       = module.data.rds_instance_id
+}
+
+output "rds_instance_endpoint" {
+  description = "Endpoint of the RDS instance"
+  value       = module.data.rds_instance_endpoint
+}
+
+output "rds_instance_address" {
+  description = "Address of the RDS instance"
+  value       = module.data.rds_instance_address
+}
+
+output "rds_port" {
+  description = "Port of the RDS instance"
+  value       = module.data.rds_port
+}
+
+output "rds_parameter_group_arn" {
+  description = "ARN of the RDS parameter group"
+  value       = module.data.rds_parameter_group_arn
+}
+
+output "redis_replication_group_arn" {
+  description = "ARN of the Redis replication group"
+  value       = module.data.redis_replication_group_arn
+}
+
+output "redis_primary_endpoint" {
+  description = "Primary endpoint of the Redis cluster"
+  value       = module.data.redis_primary_endpoint
+}
+
+output "redis_reader_endpoint" {
+  description = "Reader endpoint of the Redis cluster"
+  value       = module.data.redis_reader_endpoint
+}
+
+output "redis_parameter_group_arn" {
+  description = "ARN of the Redis parameter group"
+  value       = module.data.redis_parameter_group_arn
+}
+
+output "s3_uploads_bucket_arn" {
+  description = "ARN of the uploads S3 bucket"
+  value       = module.data.s3_uploads_bucket_arn
+}
+
+output "s3_backups_bucket_arn" {
+  description = "ARN of the backups S3 bucket"
+  value       = module.data.s3_backups_bucket_arn
+}
+
+output "s3_logs_bucket_arn" {
+  description = "ARN of the logs S3 bucket"
+  value       = module.data.s3_logs_bucket_arn
+}
+
+output "s3_frontend_bucket_arn" {
+  description = "ARN of the frontend S3 bucket"
+  value       = module.data.s3_frontend_bucket_arn
+}
+
+output "s3_frontend_bucket_id" {
+  description = "ID of the frontend S3 bucket"
+  value       = module.data.s3_frontend_bucket_id
+}
+
+output "backup_vault_arn" {
+  description = "ARN of the primary backup vault"
+  value       = module.data.backup_vault_arn
+}
+
+output "backup_kms_key_arn" {
+  description = "ARN of the backup KMS key"
+  value       = module.data.backup_kms_key_arn
+}
+
+output "backup_dr_vault_arn" {
+  description = "ARN of the DR backup vault"
+  value       = module.data.backup_dr_vault_arn
+}
+
+output "backup_daily_plan_arn" {
+  description = "ARN of the daily backup plan"
+  value       = module.data.backup_daily_plan_arn
+}
+
+output "backup_weekly_plan_arn" {
+  description = "ARN of the weekly backup plan"
+  value       = module.data.backup_weekly_plan_arn
+}
+
+# --------------- IAM ---------------
+
+output "iam_ec2_role_arn" {
+  description = "ARN of the EC2 IAM role"
+  value       = aws_iam_role.ec2.arn
+}
+
+output "iam_lambda_role_arn" {
+  description = "ARN of the Lambda IAM role"
+  value       = aws_iam_role.lambda.arn
+}
+
+output "iam_backup_role_arn" {
+  description = "ARN of the Backup IAM role"
+  value       = aws_iam_role.backup.arn
+}
+
+output "iam_ec2_ssm_policy_arn" {
+  description = "ARN of the EC2 SSM policy"
+  value       = aws_iam_policy.ec2_ssm.arn
+}
+
+output "iam_lambda_basic_policy_arn" {
+  description = "ARN of the Lambda basic policy"
+  value       = aws_iam_policy.lambda_basic.arn
+}
+
+# --------------- Route53 ---------------
+
+output "route53_zone_id" {
+  description = "ID of the Route53 hosted zone"
+  value       = aws_route53_zone.main.zone_id
+}
+
+output "route53_zone_arn" {
+  description = "ARN of the Route53 hosted zone"
+  value       = aws_route53_zone.main.arn
+}
+
+output "route53_health_check_id" {
+  description = "ID of the Route53 health check"
+  value       = aws_route53_health_check.api.id
+}
+
+# --------------- ACM ---------------
+
+output "acm_certificate_arn" {
+  description = "ARN of the ACM SSL/TLS certificate"
+  value       = aws_acm_certificate.frontend.arn
+}
+
+# --------------- CloudFront ---------------
+
+output "cloudfront_distribution_id" {
+  description = "ID of the CloudFront distribution"
+  value       = aws_cloudfront_distribution.frontend.id
+}
+
+output "cloudfront_distribution_arn" {
+  description = "ARN of the CloudFront distribution"
+  value       = aws_cloudfront_distribution.frontend.arn
+}
+
+output "cloudfront_distribution_domain" {
+  description = "Domain name of the CloudFront distribution"
+  value       = aws_cloudfront_distribution.frontend.domain_name
+}
+
+output "cloudfront_oai_id" {
+  description = "ID of the CloudFront origin access identity"
+  value       = aws_cloudfront_origin_access_identity.frontend.id
+}
+
+# --------------- WAF ---------------
+
+output "waf_web_acl_arn" {
+  description = "ARN of the WAF web ACL"
+  value       = aws_wafv2_web_acl.app.arn
+}
+
+output "waf_web_acl_id" {
+  description = "ID of the WAF web ACL"
+  value       = aws_wafv2_web_acl.app.id
+}
+
+# --------------- CloudWatch ---------------
+
+output "cloudwatch_log_group_arn" {
+  description = "ARN of the CloudWatch log group"
+  value       = aws_cloudwatch_log_group.app.arn
+}
+
+output "cloudwatch_dashboard_name" {
+  description = "Name of the CloudWatch dashboard"
+  value       = aws_cloudwatch_dashboard.main.dashboard_name
+}
+
+output "alarm_cpu_high_arn" {
+  description = "ARN of the CPU high alarm"
+  value       = aws_cloudwatch_metric_alarm.cpu_high.arn
+}
+
+output "alarm_memory_high_arn" {
+  description = "ARN of the memory high alarm"
+  value       = aws_cloudwatch_metric_alarm.memory_high.arn
+}
+
+output "alarm_errors_high_arn" {
+  description = "ARN of the errors high alarm"
+  value       = aws_cloudwatch_metric_alarm.errors_high.arn
+}
+
+# --------------- SNS ---------------
+
+output "sns_topic_arn" {
+  description = "ARN of the SNS alert topic"
+  value       = aws_sns_topic.alerts.arn
+}
+
+# --------------- Secrets Manager ---------------
+
+output "secrets_manager_secret_arn" {
+  description = "ARN of the Secrets Manager secret"
+  value       = aws_secretsmanager_secret.app.arn
+}
+
+output "secrets_manager_secret_id" {
+  description = "ID of the Secrets Manager secret"
+  value       = aws_secretsmanager_secret.app.id
+}
+
+# --------------- Workspace ---------------
+
+output "workspace_name" {
+  description = "Current Terraform workspace"
+  value       = terraform.workspace
+}
+
+output "environment" {
+  description = "Deployment environment"
+  value       = var.environment
+}
+
+output "common_tags" {
+  description = "Standard tags applied to all resources"
+  value       = local.common_tags
+}

--- a/infrastructure/terraform/variables.tf
+++ b/infrastructure/terraform/variables.tf
@@ -1,7 +1,7 @@
 # =============================================================
 # Root module variable definitions
-# All variable declarations are consolidated here to avoid
-# duplicate-variable errors when Terraform loads the module.
+# All variable declarations are consolidated here. Duplicate
+# declarations in individual .tf files have been removed.
 # =============================================================
 
 # --------------- General ---------------
@@ -35,26 +35,42 @@ variable "project_name" {
   default     = "vertexchain"
 }
 
-# --------------- Networking ---------------
-
-variable "vpc_id" {
-  description = "VPC ID"
+variable "domain_name" {
+  description = "Custom domain name for Route53 / ACM / CloudFront"
   type        = string
+  default     = "vertexchain.io"
 }
+
+variable "alert_email" {
+  description = "Email address for SNS alert notifications"
+  type        = string
+  default     = "ops@vertexchain.io"
+}
+
+# --------------- Networking ---------------
 
 variable "vpc_cidr" {
   description = "VPC CIDR block"
   type        = string
+  default     = "10.0.0.0/16"
 }
 
-variable "private_subnet_ids" {
-  description = "List of private subnet IDs"
+variable "availability_zones" {
+  description = "List of availability zones to deploy into"
   type        = list(string)
+  default     = ["us-east-1a", "us-east-1b"]
 }
 
-variable "public_subnet_ids" {
-  description = "List of public subnet IDs"
+variable "public_subnet_cidrs" {
+  description = "CIDR blocks for public subnets (one per AZ)"
   type        = list(string)
+  default     = ["10.0.1.0/24", "10.0.2.0/24"]
+}
+
+variable "private_subnet_cidrs" {
+  description = "CIDR blocks for private subnets (one per AZ)"
+  type        = list(string)
+  default     = ["10.0.11.0/24", "10.0.12.0/24"]
 }
 
 # --------------- Tags ---------------
@@ -71,35 +87,24 @@ variable "owner" {
   default     = "platform-team"
 }
 
-# --------------- RDS ---------------
+# --------------- Compute ---------------
 
-variable "db_instance_class" {
-  description = "RDS instance class (e.g. db.t3.micro for dev, db.t3.medium for prod)"
+variable "ami_id" {
+  description = "AMI ID for EC2 instances (ASG launch template)"
   type        = string
-  default     = "db.t3.micro"
 }
 
-variable "db_password" {
-  description = "RDS master password — supply via AWS Secrets Manager or CI secret"
+variable "instance_type" {
+  description = "EC2 instance type for ASG launch template"
   type        = string
-  sensitive   = true
+  default     = "t3.medium"
 }
 
-# --------------- ElastiCache / Redis ---------------
-
-variable "redis_node_type" {
-  description = "ElastiCache node type (e.g. cache.t3.micro)"
+variable "eks_version" {
+  description = "Kubernetes version for the EKS cluster"
   type        = string
-  default     = "cache.t3.micro"
+  default     = "1.29"
 }
-
-variable "redis_num_cache_nodes" {
-  description = "Number of Redis cache nodes (≥2 enables automatic failover)"
-  type        = number
-  default     = 1
-}
-
-# --------------- EKS node group ---------------
 
 variable "eks_node_instance_type" {
   description = "EC2 instance type for EKS managed node group"
@@ -141,6 +146,34 @@ variable "asg_max_size" {
 
 variable "asg_desired_size" {
   description = "Desired ASG capacity"
+  type        = number
+  default     = 1
+}
+
+# --------------- RDS ---------------
+
+variable "db_instance_class" {
+  description = "RDS instance class (e.g. db.t3.micro for dev, db.t3.medium for prod)"
+  type        = string
+  default     = "db.t3.micro"
+}
+
+variable "db_password" {
+  description = "RDS master password — supply via AWS Secrets Manager or CI secret"
+  type        = string
+  sensitive   = true
+}
+
+# --------------- ElastiCache / Redis ---------------
+
+variable "redis_node_type" {
+  description = "ElastiCache node type (e.g. cache.t3.micro)"
+  type        = string
+  default     = "cache.t3.micro"
+}
+
+variable "redis_num_cache_nodes" {
+  description = "Number of Redis cache nodes (>=2 enables automatic failover)"
   type        = number
   default     = 1
 }


### PR DESCRIPTION
## Summary
Resolves #164 – Refactor infrastructure/terraform/ from flat .tf files into a composable module structure.

## Changes

- **Create main.tf**: Root module entry point orchestrating network, compute, and data submodules plus IAM, CloudFront, WAF, Route53, ACM, CloudWatch, SNS, and Secrets Manager resources
- **Create outputs.tf**: Surfaces ARNs for every created resource (60+ outputs)
- **Consolidate variables.tf**: Single-source-of-truth, removing 12 duplicate variable declarations
- **Create modules/network**: VPC, subnets, route tables, NAT gateway, NACLs, security groups
- **Create modules/compute**: EKS cluster + node groups, ALB + target groups + listeners, ASG + launch templates
- **Create modules/data**: RDS PostgreSQL, ElastiCache Redis, S3 buckets (uploads/backups/logs/frontend), backup vaults + KMS keys + plans
- **Archive old flat files**: 43 previous .tf files moved to archive/ for migration reference
- **Update env tfvars**: All 3 environments updated with new variables

## Acceptance Criteria
- [x] Root module (main.tf, variables.tf, outputs.tf) created
- [x] Submodules split into network, compute, data
- [x] Outputs surface ARNs of every created resource
- [x] Fixes duplicate resource definitions (e.g., aws_security_group.alb defined in both alb.tf and security-groups.tf)
- [x] Fixes duplicate variable declarations across 12 files
- [x] Properly passes aws.dr provider alias to data module for cross-region backup