### PR TITLE
fix(ci): update cargo-deny config for v0.20+ and fix cargo-audit advisories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,53 @@ jobs:
       - name: cargo build (wasm32 release)
         run: cargo build --locked --workspace --target wasm32-unknown-unknown --release
 
+  contracts-audit:
+    name: Contracts Audit (cargo-deny / cargo-audit)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: contracts
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
+      - name: Cache cargo artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: contracts
+
+      - name: Install cargo-deny
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-deny
+
+      - name: Install cargo-audit
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-audit
+
+      # Scan for license conflicts, duplicate crate versions, and
+      # unmaintained/vulnerable dependencies. The deny.toml config
+      # controls thresholds and allow-lists.
+      - name: cargo deny check
+        run: cargo deny check --show-stats
+
+      # Fetch the latest RustSec advisory database and compare against
+      # every crate in the workspace. Exits non-zero (fails the build)
+      # when any advisory is found.
+      #
+      # Unmaintained transitive dependencies from the Soroban SDK cannot
+      # be upgraded at the workspace level and are explicitly ignored:
+      #   RUSTSEC-2024-0388 — derivative v2.2.0 (unmaintained)
+      #   RUSTSEC-2024-0436 — paste v1.0.15 (unmaintained)
+      - name: cargo audit
+        run: cargo audit --deny=warnings --ignore RUSTSEC-2024-0388 --ignore RUSTSEC-2024-0436
+
   backend:
     uses: ./.github/workflows/node-matrix.yml
     with:

--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -386,12 +386,12 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.11"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -808,9 +808,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-derive"
@@ -1423,30 +1423,30 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.36"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.18"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",

--- a/contracts/deny.toml
+++ b/contracts/deny.toml
@@ -1,0 +1,85 @@
+# cargo-deny configuration for VertexChain Solidity/Soroban contracts.
+#
+# This file is consumed by `cargo deny check`, which is invoked during CI
+# (see the `contracts-audit` job in .github/workflows/ci.yml).
+#
+# Reference: https://embarkstudios.github.io/cargo-deny/
+
+[advisories]
+# cargo-deny v0.20+ always treats vulnerability advisories as hard errors.
+# No `vulnerability` key is needed — it is enabled by default.
+#
+# Scope for unmaintained crate advisories:
+#   "all"       — check every crate in the dependency graph.
+#   "workspace" — only check workspace members.
+#   "transitive"— check workspace members and their transitive deps.
+#   "none"      — skip unmaintained checks entirely.
+unmaintained = "workspace"
+# Lint level for yanked crate advisories:
+#   "deny"  — fail the build.
+#   "warn"  — emit a warning but don't fail.
+#   "allow" — silently ignore.
+yanked = "warn"
+# Scope for unsoundness advisories (same values as unmaintained).
+# Default is "workspace".
+unsound = "workspace"
+# Ignore known, accepted-risk advisories here. Each entry is the advisory ID
+# from https://rustsec.org/advisories/.
+ignore = []
+
+[licenses]
+# cargo-deny v0.20+ is deny-by-default: anything not in `allow` is denied.
+# Allow-listed SPDX identifiers — all transitive dependencies must be covered
+# by one of these. Add others when a new dependency introduces a license not
+# already listed here. OSI-approved / FSF-free / commonly-used OSS licenses
+# are preferred; proprietary or copy-left licenses should be reviewed before
+# being added.
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC0-1.0",
+    "ISC",
+    "Unicode-3.0",
+    "Unlicense",
+    "Zlib",
+    "OpenSSL",
+    "MPL-2.0",
+]
+# Confidence threshold for license file detection (0.0 to 1.0).
+confidence-threshold = 0.8
+# Suppress warnings when an allow-listed license is not used by any crate.
+unused-allowed-license = "allow"
+# Per-crate exceptions may be listed here for crates that need a license
+# not in the global allow-list. Add entries like:
+# [[licenses.exceptions]]
+# allow = ["Zlib"]
+# name = "adler32"
+# version = "1.0"
+
+[bans]
+# Prevent duplicate versions of the same crate in the dependency graph.
+# Multiple versions are a source of bloat and can silently introduce
+# incompatibilities.
+multiple-versions = "warn"
+# Crates whose duplicate versions are accepted (e.g., when two different major
+# versions are required by separate dependencies).
+# skip = [
+#     { name = "syn", version = "1" },
+# ]
+skip = []
+# Crates whose transitive dependency trees are ignored for duplicate detection.
+# skip-tree = [
+#     { name = "criterion", version = "0.5" },
+# ]
+skip-tree = []
+
+[sources]
+# Only allow crates published to crates.io. Git / path dependencies should
+# be rare and reviewed.
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-git = []
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]


### PR DESCRIPTION
## Summary

Fixes the failing Contracts Audit (cargo-deny / cargo-audit) CI check introduced in #371.

## Changes

### contracts/deny.toml — Migrated to cargo-deny v0.20+ format
- Removed deprecated keys: vulnerability, severity-threshold, unlicensed, deny
- Converted unmaintained/unsound to scope strings (workspace)
- Converted yanked to lint level string (warn)
- Added unused-allowed-license = allow for clean CI output

### contracts/Cargo.lock — Fixed vulnerability
- Updated time 0.3.36 to 0.3.47 to fix RUSTSEC-2026-0009 (DoS via stack exhaustion)

### .github/workflows/ci.yml — Fixed cargo-audit warnings
- Added --ignore RUSTSEC-2024-0388 (derivative) and --ignore RUSTSEC-2024-0436 (paste) for unmaintained Soroban SDK transitive deps

## Verification

Both checks pass locally:
- cargo deny check --show-stats → 0 errors
- cargo audit --deny=warnings → 0 vulnerabilities found