### PR TITLE
feat(test): add data-testid hooks to map components for stable e2e

### DIFF
--- a/Frontend/CONTRIBUTING.md
+++ b/Frontend/CONTRIBUTING.md
@@ -1,0 +1,94 @@
+# Frontend Contributing Guidelines
+
+For general environment setup, monorepo layout, git workflow, and PR conventions, please refer to the [Root CONTRIBUTING.md](../../CONTRIBUTING.md). This document covers **Frontend (Next.js) workspace-specific** rules only.
+
+## Table of Contents
+
+- [Project Layout](#project-layout)
+- [Component Conventions](#component-conventions)
+- [Accessibility (a11y)](#accessibility-a11y)
+- [E2E Testing & `data-testid` Convention](#e2e-testing--data-testid-convention)
+- [Unit Tests](#unit-tests)
+
+## Project Layout
+
+```
+Frontend/
+├── src/
+│   ├── app/           # Next.js App Router pages, layouts, and global styles
+│   ├── components/    # Reusable UI (split by feature folder, e.g. `map/`, `landing/`)
+│   └── styles/        # Global CSS and Tailwind-related assets
+├── e2e/               # Playwright end-to-end tests
+├── public/            # Static assets served as-is
+└── *.config.ts        # next.config, tailwind.config, playwright.config, vitest.config
+```
+
+Prefer **feature folders** under `src/components/`. Each folder owns its components, tests, and internal helpers (e.g. `src/components/map/` exports `Map.tsx`, `AddGistModal.tsx`, `MapLoader.tsx`, and co-located `*.test.tsx` files).
+
+## Component Conventions
+
+- **Client Components** must start with `'use client';` at the top of the file. Server Components are the default — add the directive only when you need hooks, browser APIs, or DOM events.
+- **Dynamic imports** for heavy libraries (Leaflet, Mapbox, etc.) must set `ssr: false` and live in a dedicated loader component (see `MapLoader.tsx`).
+- Use **Tailwind utility classes** for styling. Avoid one-off inline `style` objects unless a value is dynamic.
+- **Export props as interfaces**, not type aliases, so they show up clearly in Storybook / generated docs.
+
+## Accessibility (a11y)
+
+Accessibility is a first-class concern, not an afterthought. Every new interactive component must:
+
+- Have a meaningful `role` when the semantic element isn't enough (e.g. `role="dialog"` for modals).
+- Expose a label for assistive tech: visible text content, `aria-label`, or an associated `<label htmlFor>` / `aria-labelledby`.
+- Trap and restore focus when implementing modals, popovers, or overlays.
+- Provide a `role="status"` / `role="alert"` and `aria-live` region for any state that changes asynchronously (geolocation, network responses, etc.).
+- Pass [`axe-core`](https://github.com/dequelabs/axe-core) with no serious/critical violations. PRs to pages under `src/app/` should be exercised by the `axe-core` Playwright checks in `Frontend/e2e/`.
+
+## E2E Testing & `data-testid` Convention
+
+End-to-end tests in `Frontend/e2e/` are written with [Playwright](https://playwright.dev/). To keep them stable across translations, copy changes, and visual refactors, we use **`data-testid` attributes** as the **primary** selector for elements that are interacted with or asserted on.
+
+### Naming
+
+- Use **kebab-case**, prefixed with the component's domain (usually the feature name) so test IDs don't collide across feature folders.
+  - ✅ `map-loader`, `map-add-gist-button`, `map-add-gist-modal`, `map-add-gist-modal-input`, `map-add-gist-modal-submit`
+  - ❌ `addButton`, `submit_btn`, `modal-input`
+- Multiple DOM roles inside one component should stack the parent prefix at the front, **concatenated with kebab-case separators — never nested**. The pattern is `<feature>-<component>-<elementKind>`. For `AddGistModal`, this becomes `map-add-gist-modal-<elementKind>` because the modal lives in the `map` feature; do not write things like `map/add-gist-modal/input` or `map_add_gist_modal_input`.
+- Use suffix words for the element kind when they're not implicit: `-button`, `-submit`, `-input`, `-title`. Avoid generic suffixes like `-wrapper` or `-container` unless there's a real wrapper div.
+
+### When to add one
+
+Add a `data-testid` only when **one of the following is true** for the element:
+
+1. A Playwright test interacts with it (clicks, fills, types).
+2. A Playwright test asserts on its presence, visibility, text content, or attributes.
+3. The element is a long-lived loading / state container whose visibility is asserted across tests (e.g. `map-loader`).
+
+**Do not** add `data-testid` to every `<div>` or layout container — only to the ones tests actually need. Test IDs are a public API for the test suite; treat them like exports.
+
+### Migrating selectors
+
+Prefer `page.getByTestId('…')` in new E2E tests. The following are considered fragile and should be migrated as you encounter them:
+
+| Fragile (avoid)                                     | Stable replacement                            |
+| ---------------------------------------------------- | --------------------------------------------- |
+| `page.getByText('Map is loading...')`                | `page.getByTestId('map-loader')`              |
+| `page.getByRole('button', { name: 'Add new gist' })` | `page.getByTestId('map-add-gist-button')`     |
+| `page.getByRole('dialog')`                           | `page.getByTestId('map-add-gist-modal')`      |
+| `page.getByLabel('Gist content')`                    | `page.getByTestId('map-add-gist-modal-input')`|
+| `page.getByRole('button', { name: /pin gist/i })`    | `page.getByTestId('map-add-gist-modal-submit')` |
+
+Keep `aria-label`, `aria-labelledby`, and visible text intact on the underlying components — they are there for screen readers and unit tests, not as e2e selectors.
+
+### Accessibility is separate
+
+A `data-testid` **never replaces** an `aria-label`, `role`, or semantic element. If you find yourself wanting to remove a label "because the test now uses `getByTestId`", don't — labels are for humans using assistive technology; test IDs are for automation. Both must coexist.
+
+## Unit Tests
+
+- Co-locate `*.test.tsx` files next to the component under test.
+- Use [`vitest`](https://vitest.dev/) + [`@testing-library/react`](https://testing-library.com/docs/react-testing-library/intro/).
+- Mock heavy third-party libraries (`react-leaflet`, `framer-motion`, `next/dynamic`) at the top of the file so tests don't load a real Leaflet map.
+- Prefer queries in this order: `getByRole` → `getByLabelText` → `getByTestId` → `getByText` (last resort). When you need a stable hook, use the same `data-testid` values as the Playwright suite so the convention is uniform across both test layers.
+
+---
+
+When in doubt, look at how `Frontend/src/components/map/` implements these rules — it's the reference example for new feature folders.

--- a/Frontend/e2e/map.spec.ts
+++ b/Frontend/e2e/map.spec.ts
@@ -1,5 +1,12 @@
 import { test, expect } from '@playwright/test';
 
+/**
+ * E2E selectors in this file use `data-testid` attributes (see
+ * `Frontend/CONTRIBUTING.md` for the naming convention). Test IDs make the
+ * suite resilient to copy changes, i18n, and visual refactors. All ARIA
+ * roles/labels remain on the underlying components and are still validated
+ * in the unit tests under `Frontend/src/components/map/`.
+ */
 test.describe('Map page — browse, gist, post', () => {
   test.beforeEach(async ({ page, context }) => {
     await context.grantPermissions(['geolocation'], { origin: 'http://localhost:3099' });
@@ -7,84 +14,100 @@ test.describe('Map page — browse, gist, post', () => {
   });
 
   test('happy path: browse landing, navigate to map, view gists, and post a new gist', async ({ page }) => {
-    await expect(page.getByText('Map is loading...')).toBeVisible({ timeout: 10_000 });
-    await expect(page.getByText('Map is loading...')).not.toBeVisible({ timeout: 15_000 });
+    // Loader appears, then disappears once the map mounts.
+    const loader = page.getByTestId('map-loader');
+    await expect(loader).toBeAttached({ timeout: 15_000 });
+    await expect(loader).toHaveCount(0, { timeout: 15_000 });
 
-    const addButton = page.getByRole('button', { name: 'Add new gist' });
+    const addButton = page.getByTestId('map-add-gist-button');
     await expect(addButton).toBeAttached({ timeout: 15_000 });
     await addButton.click({ force: true, timeout: 5_000 });
 
-    const modal = page.getByRole('dialog');
+    const modal = page.getByTestId('map-add-gist-modal');
     await expect(modal).toBeVisible({ timeout: 5_000 });
     await expect(modal).toHaveAttribute('aria-modal', 'true');
+    // Title still rendered (we just don't couple to its exact copy).
+    await expect(modal.locator('#add-gist-title')).toBeVisible();
 
-    await expect(page.getByText('Pin a New Gist')).toBeVisible();
-    const textarea = page.getByLabel('Gist content');
+    const textarea = page.getByTestId('map-add-gist-modal-input');
     await expect(textarea).toBeVisible();
 
     const gistText = 'E2E test gist — great suya spot at this location!';
     await textarea.fill(gistText);
     await expect(textarea).toHaveValue(gistText);
 
-    await page.getByRole('button', { name: /pin gist/i }).click();
+    const submit = page.getByTestId('map-add-gist-modal-submit');
+    await expect(submit).toBeEnabled();
+    await submit.click();
 
-    await expect(page.getByRole('button', { name: /pinning\.\.\./i })).toBeVisible({ timeout: 3_000 });
-    await expect(page.getByRole('button', { name: /pinning\.\.\./i })).not.toBeVisible({ timeout: 5_000 });
+    // Loading state: button disabled while the gist is being "pinned".
+    // The modal must remain open during the pin (it closes only after the simulated response).
+    await expect(modal).toBeVisible();
+    await expect(submit).toBeDisabled({ timeout: 3_000 });
+    // After the simulated 2s submit, modal exits, button becomes enabled again, and textarea resets.
+    // The textarea must still be in DOM at this point (framer-motion's spring exit keeps it mounted
+    // long enough for Playwright to read its value); guard explicitly so a future flake doesn't
+    // surface as a 'no such element' mystery.
+    await expect(submit).toBeEnabled({ timeout: 5_000 });
+    await expect(textarea).toBeVisible();
+    await expect(textarea).toHaveValue('');
 
     await expect(modal).not.toBeVisible();
   });
 
   test('negative: cannot submit with empty gist content', async ({ page }) => {
-    await expect(page.getByText('Map is loading...')).toBeVisible({ timeout: 10_000 });
-    await expect(page.getByText('Map is loading...')).not.toBeVisible({ timeout: 15_000 });
+    await expect(page.getByTestId('map-loader')).toHaveCount(0, { timeout: 15_000 });
 
-    const addButton = page.getByRole('button', { name: 'Add new gist' });
+    const addButton = page.getByTestId('map-add-gist-button');
     await expect(addButton).toBeAttached({ timeout: 15_000 });
     await addButton.click({ force: true, timeout: 5_000 });
 
-    await expect(page.getByRole('dialog')).toBeVisible();
+    const modal = page.getByTestId('map-add-gist-modal');
+    await expect(modal).toBeVisible();
 
-    const textarea = page.getByLabel('Gist content');
+    const textarea = page.getByTestId('map-add-gist-modal-input');
     await expect(textarea).toBeVisible();
     await expect(textarea).toHaveValue('');
 
-    await page.getByRole('button', { name: /pin gist/i }).click();
+    const submit = page.getByTestId('map-add-gist-modal-submit');
+    await submit.click();
 
-    await expect(page.getByRole('dialog')).toBeVisible();
-    await expect(page.getByRole('button', { name: /pin gist/i })).toBeVisible();
+    // Empty submit is a no-op: modal stays open and the submit button is still visible/enabled.
+    await expect(modal).toBeVisible();
+    await expect(submit).toBeVisible();
+    await expect(submit).toBeEnabled();
   });
 
   test('negative: escape key closes the modal without posting', async ({ page }) => {
-    await expect(page.getByText('Map is loading...')).toBeVisible({ timeout: 10_000 });
-    await expect(page.getByText('Map is loading...')).not.toBeVisible({ timeout: 15_000 });
+    await expect(page.getByTestId('map-loader')).toHaveCount(0, { timeout: 15_000 });
 
-    const addButton = page.getByRole('button', { name: 'Add new gist' });
+    const addButton = page.getByTestId('map-add-gist-button');
     await expect(addButton).toBeAttached({ timeout: 15_000 });
     await addButton.click({ force: true, timeout: 5_000 });
 
-    const modal = page.getByRole('dialog');
+    const modal = page.getByTestId('map-add-gist-modal');
     await expect(modal).toBeVisible();
 
-    await page.getByLabel('Gist content').fill('This should not appear');
+    await page.getByTestId('map-add-gist-modal-input').fill('This should not appear');
     await page.keyboard.press('Escape');
 
     await expect(modal).not.toBeVisible();
   });
 
   test('negative: clicking the backdrop overlay closes the modal without posting', async ({ page }) => {
-    await expect(page.getByText('Map is loading...')).toBeVisible({ timeout: 10_000 });
-    await expect(page.getByText('Map is loading...')).not.toBeVisible({ timeout: 15_000 });
+    await expect(page.getByTestId('map-loader')).toHaveCount(0, { timeout: 15_000 });
 
-    const addButton = page.getByRole('button', { name: 'Add new gist' });
+    const addButton = page.getByTestId('map-add-gist-button');
     await expect(addButton).toBeAttached({ timeout: 15_000 });
     await addButton.click({ force: true, timeout: 5_000 });
 
-    const modal = page.getByRole('dialog');
+    const modal = page.getByTestId('map-add-gist-modal');
     await expect(modal).toBeVisible();
 
-    await page.getByLabel('Gist content').fill('This should also not appear');
+    await page.getByTestId('map-add-gist-modal-input').fill('This should also not appear');
 
-    await page.mouse.click(100, 100);
+    // Click outside the dialog (top-left of the viewport, well outside the modal box).
+    await page.mouse.click(50, 50);
 
     await expect(modal).not.toBeVisible();
   });

--- a/Frontend/src/components/map/AddGistModal.tsx
+++ b/Frontend/src/components/map/AddGistModal.tsx
@@ -72,6 +72,7 @@ export default function AddGistModal({
             role="dialog"
             aria-modal="true"
             aria-labelledby="add-gist-title"
+            data-testid="map-add-gist-modal"
             initial={{ y: '100%' }}
             animate={{ y: '0%' }}
             exit={{ y: '100%' }}
@@ -88,12 +89,14 @@ export default function AddGistModal({
               placeholder="What's the gist? (max 280 characters)"
               maxLength={280}
               aria-label="Gist content"
+              data-testid="map-add-gist-modal-input"
               className="w-full p-3 border rounded-lg h-28 bg-gray-50 dark:bg-gray-700 dark:text-white dark:border-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500"
             />
             <button
               onClick={handleSubmit}
               disabled={isLoading}
               aria-busy={isLoading}
+              data-testid="map-add-gist-modal-submit"
               className="w-full mt-4 px-6 py-3 text-lg font-semibold text-white  rounded-lg   bg-gradient-to-r from-purple-600 via-blue-600 to-pink-400 
                             bg-[size:200%_auto] 
                             hover:bg-[position:100%_center] 

--- a/Frontend/src/components/map/Map.tsx
+++ b/Frontend/src/components/map/Map.tsx
@@ -119,6 +119,7 @@ export default function Map() {
 
       <motion.button
         onClick={() => setIsModalOpen(true)}
+        data-testid="map-add-gist-button"
         // 3. Animation props for pulsing effect
         animate={{ scale: [1, 1.1, 1] }}
         transition={{ duration: 1.5, repeat: Infinity, ease: 'easeInOut' }}

--- a/Frontend/src/components/map/MapLoader.tsx
+++ b/Frontend/src/components/map/MapLoader.tsx
@@ -8,7 +8,7 @@ export default function MapLoader() {
     () =>
       dynamic(() => import('@/components/map/Map'), {
         loading: () => (
-          <div role="status" aria-live="polite" className="flex items-center justify-center h-64 text-gray-400">
+          <div role="status" aria-live="polite" data-testid="map-loader" className="flex items-center justify-center h-64 text-gray-400">
             <span>Map is loading...</span>
           </div>
         ),


### PR DESCRIPTION
Closes #153

- MapLoader: add map-loader

- Map: add map-add-gist-button

- AddGistModal: add map-add-gist-modal, map-add-gist-modal-input, map-add-gist-modal-submit

- Migrate Frontend/e2e/map.spec.ts to getByTestId selectors so the suite survives i18n / copy changes / visual refactors

- Add Frontend/CONTRIBUTING.md documenting the kebab-case data-testid convention (issue #153)

- All aria-labels, aria-labelledby, role, and visible text retained for assistive tech and unit tests.

# Pull Request

Please provide a short description of the change and link any related issues.

## PR Title Format Guidelines (Required)
Please ensure your PR title follows the Conventional Commits header format:
`type(scope): subject` or `type: subject`
- **Type** must be lowercase (e.g., `docs`, `feat`, `fix`, `chore`, `ci`, etc.).
- **Subject** must be ≤ 72 characters.
- *Examples*: `docs: add initial ADRs`, `feat(api): add user auth`


## Description

- Summary of changes
- Related issue: # (if applicable)

## Checklist

- [ ] Tests added or updated
- [ ] Documentation updated (README, docs, comments)
- [ ] Linting passes
- [ ] Type checking passes (if applicable)
- [ ] Relevant issue linked
- [ ] Changelog updated (if applicable)

## Security

If this change includes anything security-sensitive (secrets, auth changes, data exposure), describe mitigations and whether coordinated disclosure is required.

## Notes for reviewers

- Anything specific reviewers should check
- How to run or reproduce the change locally
