### PR TITLE
fix(gists): idempotent write path across IPFS, Soroban, and Postgres

### DIFF
--- a/Backend/README.md
+++ b/Backend/README.md
@@ -168,13 +168,16 @@ Content-Type: application/json
 
 `authorAddress` is optional — anonymous posting is fully supported.
 
+**Idempotency.** Send an `Idempotency-Key` header (any unique string, e.g. a UUID) on every post. The server records a durable write attempt *before* the irreversible on-chain call and replays it on retry, so a client that retries after a mid-write failure gets the original gist instead of a second on-chain record. If the header is omitted, the server derives a deterministic key from the request content, so identical retries still deduplicate. Reusing a key with a *different* body returns `422`.
+
 **What happens internally:**
 1. Validate + sanitise input
 2. Pin content to IPFS → receive CID
 3. Derive `locationCell` from `(lat, lon)` via geohash
-4. Submit `post_gist(author, locationCell, contentHash)` to Soroban
-5. Persist the record in Postgres
-6. Return the created gist
+4. Persist a `pending` write attempt (keyed by the idempotency key) in Postgres
+5. Submit `post_gist(author, locationCell, contentHash)` to Soroban
+6. Record the on-chain `gistId`/`txHash` (`chained`) and insert the `gists` row (`committed`)
+7. Return the created gist
 
 ### Correct a Gist
 
@@ -217,6 +220,21 @@ Table: `gists`
 | `created_at` | `timestamptz` | |
 | `previous_cid` | `text` | Nullable — IPFS CID this gist replaced, set on edit |
 | `edited_at` | `timestamptz` | Nullable — set on edit |
+
+### Idempotency ledger (`gist_write_attempts`)
+
+A separate table, one row per logical post attempt, keyed by `idempotency_key` (unique). It carries the write-path state machine:
+
+| Column | Type | Notes |
+|---|---|---|
+| `idempotency_key` | `varchar(255)` UNIQUE | Client header value, or a content-derived fallback |
+| `request_hash` | `varchar(64)` | Detects key reuse with a different body (`422`) |
+| `content_hash` | `varchar(100)` | IPFS CID pinned for this attempt |
+| `stellar_gist_id` / `tx_hash` | `varchar(80)` | Filled once the on-chain write completes (`chained`) |
+| `gist_id` | `uuid` | The persisted `gists.id`, set on `committed` |
+| `status` | `varchar(16)` | `pending` → `chained` → `committed` |
+
+`stellar_gist_id` is enforced unique on `gists` so the final insert and the indexer's `upsertFromEvent` both dedupe at the DB layer.
 
 ---
 

--- a/Backend/src/common/middleware/idempotency.middleware.spec.ts
+++ b/Backend/src/common/middleware/idempotency.middleware.spec.ts
@@ -34,6 +34,10 @@ describe('Idempotency-Key middleware', () => {
       res.status(200).json({ count: req.body.length });
     });
 
+    app.post('/flaky', (req, res) => {
+      res.status(500).json({ error: 'boom' });
+    });
+
     app.get('/health', (req, res) => {
       res.status(200).json({ status: 'ok' });
     });
@@ -152,5 +156,46 @@ describe('Idempotency-Key middleware', () => {
     await request(app).post('/gists').send({ content: 'no-key' }).expect(200);
 
     expect(cache.set).not.toHaveBeenCalled();
+  });
+
+  it('records a failed attempt when the handler responds with an error status', async () => {
+    cache.get.mockResolvedValue(null);
+
+    await request(app)
+      .post('/flaky')
+      .set('Idempotency-Key', 'key-fail')
+      .send({ content: 'boom' })
+      .expect(500);
+
+    expect(cache.set).toHaveBeenCalledTimes(1);
+    const setArgs = cache.set.mock.calls[0];
+    expect(setArgs[0]).toBe('idemp:key-fail');
+    expect(setArgs[1]).toMatchObject({ state: 'failed', status: 500, body: { error: 'boom' } });
+  });
+
+  it('allows a retry to proceed after a failed attempt instead of replaying the error', async () => {
+    cache.get.mockResolvedValue(null);
+
+    await request(app)
+      .post('/flaky')
+      .set('Idempotency-Key', 'key-fail')
+      .send({ content: 'boom' })
+      .expect(500);
+
+    // The first attempt recorded a failed entry.
+    const failedEntry = cache.set.mock.calls[0][1];
+    expect(failedEntry).toMatchObject({ state: 'failed', status: 500 });
+
+    // A retry of the same request reaches the handler again instead of
+    // replaying the cached 500 or returning 422.
+    cache.get.mockResolvedValue(failedEntry);
+    const res = await request(app)
+      .post('/flaky')
+      .set('Idempotency-Key', 'key-fail')
+      .send({ content: 'boom' })
+      .expect(500);
+
+    expect(res.headers['idempotency-replayed']).toBeUndefined();
+    expect(cache.set).toHaveBeenCalledTimes(2);
   });
 });

--- a/Backend/src/common/middleware/idempotency.middleware.ts
+++ b/Backend/src/common/middleware/idempotency.middleware.ts
@@ -3,6 +3,9 @@ import { createHash } from 'crypto';
 import { CacheService } from '../../cache/cache.service';
 
 interface CachedEntry {
+  // `state` is absent on entries written before this change; treat those as
+  // completed (`done`) responses.
+  state?: 'done' | 'failed';
   status: number;
   body: unknown;
   reqHash: string;
@@ -12,6 +15,11 @@ function hashRequest(method: string, path: string, body: unknown): string {
   return createHash('sha256')
     .update(`${method}:${path}:${JSON.stringify(body)}`)
     .digest('hex');
+}
+
+function replayCached(res: Response, status: number, body: unknown): void {
+  res.setHeader('Idempotency-Replayed', 'true');
+  res.status(status).json(body);
 }
 
 export function idempotencyMiddleware(cacheService: CacheService) {
@@ -38,23 +46,40 @@ export function idempotencyMiddleware(cacheService: CacheService) {
           return;
         }
 
-        res.setHeader('Idempotency-Replayed', 'true');
-        res.status(cached.status).json(cached.body);
+        if (cached.state === 'failed') {
+          // The previous attempt failed and never produced a completed
+          // response. Allow the retry to proceed instead of replaying an error.
+          armResponseRecording(cacheService, res, cacheKey, reqHash);
+          next();
+          return;
+        }
+
+        replayCached(res, cached.status, cached.body);
         return;
       }
 
-      const originalJson = res.json.bind(res);
-      res.json = function (body: unknown) {
-        const ttl = parseInt(process.env.IDEMPOTENCY_TTL_SECONDS ?? '86400', 10);
-        void cacheService.set(
-          cacheKey,
-          { status: res.statusCode, body, reqHash } satisfies CachedEntry,
-          ttl,
-        );
-        return originalJson(body);
-      };
-
+      armResponseRecording(cacheService, res, cacheKey, reqHash);
       next();
     })();
+  };
+}
+
+function armResponseRecording(
+  cacheService: CacheService,
+  res: Response,
+  cacheKey: string,
+  reqHash: string,
+): void {
+  const originalJson = res.json.bind(res);
+  res.json = function (body: unknown) {
+    const ttl = parseInt(process.env.IDEMPOTENCY_TTL_SECONDS ?? '86400', 10);
+    const entry: CachedEntry = {
+      state: res.statusCode >= 400 ? 'failed' : 'done',
+      status: res.statusCode,
+      body,
+      reqHash,
+    };
+    void cacheService.set(cacheKey, entry, ttl);
+    return originalJson(body);
   };
 }

--- a/Backend/src/database/migrations/1700000000004-AddGistWriteAttempts.ts
+++ b/Backend/src/database/migrations/1700000000004-AddGistWriteAttempts.ts
@@ -1,0 +1,57 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddGistWriteAttempts1700000000004 implements MigrationInterface {
+  name = 'AddGistWriteAttempts1700000000004';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Durable idempotency ledger for the gist write path. One row per logical
+    // post attempt, keyed by the client Idempotency-Key (or a content-derived
+    // fallback). The row survives the irreversible Soroban write so a retry can
+    // resume instead of posting a second on-chain gist.
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "gist_write_attempts" (
+        "id"                 UUID             NOT NULL DEFAULT gen_random_uuid(),
+        "idempotency_key"    VARCHAR(255)     NOT NULL,
+        "request_hash"       VARCHAR(64)      NOT NULL,
+        "content"            TEXT             NOT NULL,
+        "lat"                DOUBLE PRECISION NOT NULL,
+        "lon"                DOUBLE PRECISION NOT NULL,
+        "location_cell"      VARCHAR(20),
+        "content_hash"       VARCHAR(100),
+        "author"             VARCHAR(80),
+        "author_verified_at" TIMESTAMPTZ,
+        "stellar_gist_id"    VARCHAR(80),
+        "tx_hash"            VARCHAR(80),
+        "gist_id"            UUID,
+        "status"             VARCHAR(16)      NOT NULL DEFAULT 'pending',
+        "created_at"         TIMESTAMPTZ      NOT NULL DEFAULT NOW(),
+        "updated_at"         TIMESTAMPTZ      NOT NULL DEFAULT NOW(),
+        CONSTRAINT "PK_gist_write_attempts_id" PRIMARY KEY ("id"),
+        CONSTRAINT "UQ_gist_write_attempts_idempotency_key" UNIQUE ("idempotency_key")
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "idx_gist_write_attempts_content_hash"
+        ON "gist_write_attempts" ("content_hash", "location_cell")
+    `);
+
+    // Enforce on-chain id dedup at the DB layer. Required for GistRepository's
+    // `ON CONFLICT (stellar_gist_id)` clauses (`upsertFromEvent` and the new
+    // idempotent `createCommitted` insert) to actually resolve. Postgres treats
+    // NULLs as distinct in a unique index, so pending rows (no on-chain id yet)
+    // are unaffected.
+    //
+    // Precondition: no existing duplicate non-NULL `stellar_gist_id` rows.
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX IF NOT EXISTS "UQ_gists_stellar_gist_id"
+        ON "gists" ("stellar_gist_id")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "UQ_gists_stellar_gist_id"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "idx_gist_write_attempts_content_hash"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "gist_write_attempts"`);
+  }
+}

--- a/Backend/src/gists/entities/gist.entity.ts
+++ b/Backend/src/gists/entities/gist.entity.ts
@@ -15,7 +15,7 @@ export class Gist {
   @Column({ type: 'varchar', length: 100, nullable: true })
   content_hash: string | null;
 
-  @Index({ unique: true })
+  @Index('UQ_gists_stellar_gist_id', { unique: true })
   @Column({ type: 'varchar', length: 80, nullable: true })
   stellar_gist_id: string | null;
 

--- a/Backend/src/gists/gist-write-attempt.repository.ts
+++ b/Backend/src/gists/gist-write-attempt.repository.ts
@@ -1,0 +1,140 @@
+import { Injectable } from '@nestjs/common';
+import { InjectDataSource } from '@nestjs/typeorm';
+import { DataSource } from 'typeorm';
+
+/**
+ * Lifecycle of a gist write attempt:
+ *
+ *   pending   — the attempt is recorded and IPFS has been pinned, but the
+ *               irreversible on-chain write has not yet been recorded.
+ *   chained   — the on-chain write completed and its `stellar_gist_id` /
+ *               `tx_hash` are durably stored; only the final Postgres insert
+ *               into `gists` remains.
+ *   committed — the `gists` row exists and is referenced by `gist_id`.
+ *
+ * The transition from `pending` to `chained` is what makes a retry idempotent:
+ * once the on-chain id is durable, a later retry can finish the DB insert
+ * without calling Soroban a second time.
+ */
+export type GistWriteAttemptStatus = 'pending' | 'chained' | 'committed';
+
+export interface GistWriteAttempt {
+  id: string;
+  idempotency_key: string;
+  request_hash: string;
+  content: string;
+  lat: number;
+  lon: number;
+  location_cell: string | null;
+  content_hash: string | null;
+  author: string | null;
+  author_verified_at: Date | null;
+  stellar_gist_id: string | null;
+  tx_hash: string | null;
+  gist_id: string | null;
+  status: GistWriteAttemptStatus;
+  created_at: Date;
+  updated_at: Date;
+}
+
+export interface CreatePendingAttemptData {
+  idempotency_key: string;
+  request_hash: string;
+  content: string;
+  lat: number;
+  lon: number;
+  location_cell: string;
+  content_hash: string;
+  author: string | null;
+  author_verified_at: Date | null;
+}
+
+const ATTEMPT_COLUMNS = `
+  id, idempotency_key, request_hash, content, lat, lon, location_cell,
+  content_hash, author, author_verified_at, stellar_gist_id, tx_hash,
+  gist_id, status, created_at, updated_at
+`;
+
+@Injectable()
+export class GistWriteAttemptRepository {
+  constructor(@InjectDataSource() private readonly dataSource: DataSource) {}
+
+  async findByKey(idempotencyKey: string): Promise<GistWriteAttempt | null> {
+    const rows = await this.dataSource.query<GistWriteAttempt[]>(
+      `SELECT ${ATTEMPT_COLUMNS} FROM gist_write_attempts WHERE idempotency_key = $1 LIMIT 1`,
+      [idempotencyKey],
+    );
+    return rows[0] ?? null;
+  }
+
+  /**
+   * Inserts a pending attempt. Returns `null` when the key already exists
+   * (a concurrent request won the insert), so the caller re-reads the winner
+   * and resumes from its state instead of proceeding in parallel.
+   */
+  async createPending(data: CreatePendingAttemptData): Promise<GistWriteAttempt | null> {
+    const rows = await this.dataSource.query<GistWriteAttempt[]>(
+      `
+      INSERT INTO gist_write_attempts (
+        idempotency_key, request_hash, content, lat, lon, location_cell,
+        content_hash, author, author_verified_at, status
+      )
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 'pending')
+      ON CONFLICT (idempotency_key) DO NOTHING
+      RETURNING ${ATTEMPT_COLUMNS}
+      `,
+      [
+        data.idempotency_key,
+        data.request_hash,
+        data.content,
+        data.lat,
+        data.lon,
+        data.location_cell,
+        data.content_hash,
+        data.author,
+        data.author_verified_at,
+      ],
+    );
+    return rows[0] ?? null;
+  }
+
+  /**
+   * Records the result of the irreversible on-chain write. Only advances a
+   * `pending` attempt; returns `null` if the attempt was already advanced by
+   * a concurrent request, in which case the caller must re-read and resume.
+   */
+  async markChained(
+    idempotencyKey: string,
+    stellarGistId: string,
+    txHash: string,
+  ): Promise<GistWriteAttempt | null> {
+    const rows = await this.dataSource.query<GistWriteAttempt[]>(
+      `
+      UPDATE gist_write_attempts
+      SET stellar_gist_id = $2,
+          tx_hash = $3,
+          status = 'chained',
+          updated_at = NOW()
+      WHERE idempotency_key = $1 AND status = 'pending'
+      RETURNING ${ATTEMPT_COLUMNS}
+      `,
+      [idempotencyKey, stellarGistId, txHash],
+    );
+    return rows[0] ?? null;
+  }
+
+  async markCommitted(idempotencyKey: string, gistId: string): Promise<GistWriteAttempt | null> {
+    const rows = await this.dataSource.query<GistWriteAttempt[]>(
+      `
+      UPDATE gist_write_attempts
+      SET gist_id = $2,
+          status = 'committed',
+          updated_at = NOW()
+      WHERE idempotency_key = $1 AND status IN ('pending', 'chained')
+      RETURNING ${ATTEMPT_COLUMNS}
+      `,
+      [idempotencyKey, gistId],
+    );
+    return rows[0] ?? null;
+  }
+}

--- a/Backend/src/gists/gist.repository.ts
+++ b/Backend/src/gists/gist.repository.ts
@@ -74,10 +74,88 @@ export class GistRepository {
         ST_X(location::geometry) AS lon,
         ST_Y(location::geometry) AS lat
       `,
-      [content, lon, lat, location_cell, content_hash, stellar_gist_id, tx_hash, author, author_verified_at],
+      [
+        content,
+        lon,
+        lat,
+        location_cell,
+        content_hash,
+        stellar_gist_id,
+        tx_hash,
+        author,
+        author_verified_at,
+      ],
     );
 
     return result[0];
+  }
+
+  /**
+   * Idempotent insert keyed on the on-chain gist id.
+   *
+   * Used by the write path after the Soroban call has produced `stellar_gist_id`.
+   * If a prior attempt already persisted this gist (a retry after a mid-write
+   * failure), the conflicting row is returned instead of inserting a duplicate.
+   * Requires the `UQ_gists_stellar_gist_id` unique index added by the
+   * `AddGistWriteAttempts1700000000004` migration.
+   */
+  async createCommitted(data: CreateGistData): Promise<Gist> {
+    const {
+      content,
+      lat,
+      lon,
+      location_cell = null,
+      content_hash = null,
+      stellar_gist_id = null,
+      tx_hash = null,
+      author = null,
+      author_verified_at = null,
+    } = data;
+
+    const inserted = await this.dataSource.query<Gist[]>(
+      `
+      INSERT INTO gists (
+        content, location, location_cell,
+        content_hash, stellar_gist_id, tx_hash, author, author_verified_at
+      )
+      VALUES (
+        $1,
+        ST_SetSRID(ST_MakePoint($2, $3), 4326)::geography,
+        $4, $5, $6, $7, $8, $9
+      )
+      ON CONFLICT (stellar_gist_id) DO NOTHING
+      RETURNING
+        id, content, location_cell, content_hash,
+        stellar_gist_id, tx_hash, author, author_verified_at, previous_cid, edited_at, created_at,
+        ST_X(location::geometry) AS lon,
+        ST_Y(location::geometry) AS lat
+      `,
+      [
+        content,
+        lon,
+        lat,
+        location_cell,
+        content_hash,
+        stellar_gist_id,
+        tx_hash,
+        author,
+        author_verified_at,
+      ],
+    );
+
+    if (inserted[0]) {
+      return inserted[0];
+    }
+
+    // Conflict — the gist was already persisted by a prior attempt.
+    const existing = await this.findByStellarGistId(stellar_gist_id as string);
+    if (existing) {
+      return existing;
+    }
+
+    throw new Error(
+      `createCommitted: insert conflicted on stellar_gist_id=${stellar_gist_id} but the row could not be re-read`,
+    );
   }
 
   async findNearby(query: NearbyQuery): Promise<PaginatedResponse<Gist>> {

--- a/Backend/src/gists/gists.controller.spec.ts
+++ b/Backend/src/gists/gists.controller.spec.ts
@@ -106,8 +106,23 @@ describe('GistsController', () => {
 
       const response = await controller.create(dto, null);
 
-      expect(service.create).toHaveBeenCalledWith(dto, null);
+      expect(service.create).toHaveBeenCalledWith(dto, null, undefined);
       expect(response).toEqual(result);
+    });
+
+    it('should forward the Idempotency-Key header to the service', async () => {
+      const dto: CreateGistDto = {
+        content: 'Great coffee spot here!',
+        lat: 9.0579,
+        lon: 7.4951,
+      };
+      const result = createMockGist({ content: dto.content });
+
+      jest.spyOn(service, 'create').mockResolvedValueOnce(result);
+
+      await controller.create(dto, null, 'key-123');
+
+      expect(service.create).toHaveBeenCalledWith(dto, null, 'key-123');
     });
 
     it('should call gistsService.create without optional author field', async () => {
@@ -122,7 +137,7 @@ describe('GistsController', () => {
 
       const response = await controller.create(dto, null);
 
-      expect(service.create).toHaveBeenCalledWith(dto, null);
+      expect(service.create).toHaveBeenCalledWith(dto, null, undefined);
       expect(response).toEqual(result);
     });
 

--- a/Backend/src/gists/gists.controller.ts
+++ b/Backend/src/gists/gists.controller.ts
@@ -3,6 +3,7 @@ import {
   BadRequestException,
   Controller,
   Get,
+  Headers,
   Post,
   Patch,
   Body,
@@ -51,8 +52,9 @@ export class GistsController {
   create(
     @Body() dto: CreateGistDto,
     @StellarVerifiedUser() stellarVerified: StellarVerified | null,
+    @Headers('idempotency-key') idempotencyKey?: string,
   ) {
-    return this.gistsService.create(dto, stellarVerified);
+    return this.gistsService.create(dto, stellarVerified, idempotencyKey);
   }
 
   @Post('batch')

--- a/Backend/src/gists/gists.module.ts
+++ b/Backend/src/gists/gists.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Gist } from './entities/gist.entity';
 import { GistRepository } from './gist.repository';
+import { GistWriteAttemptRepository } from './gist-write-attempt.repository';
 import { GistsService } from './gists.service';
 import { GistsController } from './gists.controller';
 import { GeoModule } from '../geo/geo.module';
@@ -11,9 +12,16 @@ import { CacheModule } from '../cache/cache.module';
 import { AuthModule } from '../auth/auth.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Gist]), GeoModule, IpfsModule, SorobanModule, CacheModule, AuthModule],
+  imports: [
+    TypeOrmModule.forFeature([Gist]),
+    GeoModule,
+    IpfsModule,
+    SorobanModule,
+    CacheModule,
+    AuthModule,
+  ],
   controllers: [GistsController],
-  providers: [GistRepository, GistsService],
+  providers: [GistRepository, GistWriteAttemptRepository, GistsService],
   exports: [GistsService],
 })
 export class GistsModule {}

--- a/Backend/src/gists/gists.service.spec.ts
+++ b/Backend/src/gists/gists.service.spec.ts
@@ -1,6 +1,8 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { GistsService } from './gists.service';
 import { GistRepository } from './gist.repository';
+import { GistWriteAttemptRepository } from './gist-write-attempt.repository';
+import { computeGistRequestHash } from './idempotency-key.util';
 import { GeoService } from '../geo/geo.service';
 import { IpfsService } from '../ipfs/ipfs.service';
 import { SorobanService } from '../soroban/soroban.service';
@@ -9,7 +11,11 @@ import { Gist } from './entities/gist.entity';
 import { CreateGistDto } from './dto/create-gist.dto';
 import { QueryGistsDto } from './dto/query-gists.dto';
 import { UpdateGistDto } from './dto/update-gist.dto';
-import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import {
+  ForbiddenException,
+  NotFoundException,
+  UnprocessableEntityException,
+} from '@nestjs/common';
 
 jest.mock('../common/utils/sanitize', () => ({
   stripHtml: jest.fn((text: string) => text),
@@ -36,6 +42,7 @@ const mockGist = (overrides?: Partial<Gist>): Gist => ({
 describe('GistsService', () => {
   let service: GistsService;
   let gistRepository: jest.Mocked<GistRepository>;
+  let writeAttemptRepository: jest.Mocked<GistWriteAttemptRepository>;
   let geoService: jest.Mocked<GeoService>;
   let ipfsService: jest.Mocked<IpfsService>;
   let sorobanService: jest.Mocked<SorobanService>;
@@ -49,9 +56,20 @@ describe('GistsService', () => {
           provide: GistRepository,
           useValue: {
             create: jest.fn(),
+            createCommitted: jest.fn(),
             findNearby: jest.fn(),
             findByGistId: jest.fn(),
+            findByStellarGistId: jest.fn(),
             update: jest.fn(),
+          },
+        },
+        {
+          provide: GistWriteAttemptRepository,
+          useValue: {
+            findByKey: jest.fn(),
+            createPending: jest.fn(),
+            markChained: jest.fn(),
+            markCommitted: jest.fn(),
           },
         },
         {
@@ -80,10 +98,17 @@ describe('GistsService', () => {
 
     service = module.get<GistsService>(GistsService);
     gistRepository = module.get(GistRepository);
+    writeAttemptRepository = module.get(GistWriteAttemptRepository);
     geoService = module.get(GeoService);
     ipfsService = module.get(IpfsService);
     sorobanService = module.get(SorobanService);
     cacheService = module.get(CacheService);
+
+    // Default to a clean (no prior attempt) write path.
+    writeAttemptRepository.findByKey.mockResolvedValue(null);
+    writeAttemptRepository.createPending.mockResolvedValue(null);
+    writeAttemptRepository.markChained.mockResolvedValue(null);
+    writeAttemptRepository.markCommitted.mockResolvedValue(null);
   });
 
   describe('createBatch()', () => {
@@ -121,7 +146,7 @@ describe('GistsService', () => {
       geoService.encode.mockReturnValue('s1t7d8c');
       ipfsService.pinJson.mockResolvedValue({ cid: 'mock_Qmabc', mock: true });
       sorobanService.postGist.mockResolvedValue({ gistId: '1', txHash: 'tx1', mock: true });
-      gistRepository.create.mockResolvedValue(mockGist());
+      gistRepository.createCommitted.mockResolvedValue(mockGist());
       cacheService.delPattern.mockResolvedValue();
 
       await service.create(dto);
@@ -134,7 +159,7 @@ describe('GistsService', () => {
       geoService.encode.mockReturnValue('s1t7d8c');
       ipfsService.pinJson.mockResolvedValue({ cid: 'mock_Qmabc', mock: true });
       sorobanService.postGist.mockResolvedValue({ gistId: '1', txHash: 'tx1', mock: true });
-      gistRepository.create.mockResolvedValue(mockGist());
+      gistRepository.createCommitted.mockResolvedValue(mockGist());
       cacheService.delPattern.mockResolvedValue();
 
       await service.create(dto);
@@ -154,7 +179,7 @@ describe('GistsService', () => {
       geoService.encode.mockReturnValue('s1t7d8c');
       ipfsService.pinJson.mockResolvedValue({ cid: 'mock_Qmabc', mock: true });
       sorobanService.postGist.mockResolvedValue({ gistId: '1', txHash: 'tx1', mock: true });
-      gistRepository.create.mockResolvedValue(mockGist());
+      gistRepository.createCommitted.mockResolvedValue(mockGist());
       cacheService.delPattern.mockResolvedValue();
 
       await service.create(dto);
@@ -162,17 +187,17 @@ describe('GistsService', () => {
       expect(sorobanService.postGist).toHaveBeenCalledWith('s1t7d8c', 'mock_Qmabc', 'GABC');
     });
 
-    it('calls GistRepository.create with all required fields', async () => {
+    it('calls GistRepository.createCommitted with all required fields', async () => {
       const dto: CreateGistDto = { content: 'Test', lat: 9.0579, lon: 7.4951 };
       geoService.encode.mockReturnValue('s1t7d8c');
       ipfsService.pinJson.mockResolvedValue({ cid: 'mock_Qmabc', mock: true });
       sorobanService.postGist.mockResolvedValue({ gistId: '42', txHash: 'tx42', mock: true });
-      gistRepository.create.mockResolvedValue(mockGist());
+      gistRepository.createCommitted.mockResolvedValue(mockGist());
       cacheService.delPattern.mockResolvedValue();
 
       await service.create(dto);
 
-      expect(gistRepository.create).toHaveBeenCalledWith({
+      expect(gistRepository.createCommitted).toHaveBeenCalledWith({
         content: 'Test',
         lat: 9.0579,
         lon: 7.4951,
@@ -191,12 +216,133 @@ describe('GistsService', () => {
       geoService.encode.mockReturnValue('s1t7d8c');
       ipfsService.pinJson.mockResolvedValue({ cid: 'cid1', mock: true });
       sorobanService.postGist.mockResolvedValue({ gistId: '1', txHash: 'tx', mock: true });
-      gistRepository.create.mockResolvedValue(gist);
+      gistRepository.createCommitted.mockResolvedValue(gist);
       cacheService.delPattern.mockResolvedValue();
 
       const result = await service.create(dto);
 
       expect(result).toBe(gist);
+    });
+
+    it('does not re-post to the chain when a retry follows a failed DB insert', async () => {
+      const dto: CreateGistDto = { content: 'Test', lat: 9.0579, lon: 7.4951 };
+      const idempotencyKey = 'key-retry';
+      const requestHash = computeGistRequestHash({
+        content: 'Test',
+        lat: 9.0579,
+        lon: 7.4951,
+      });
+      const chainedAttempt = {
+        id: 'attempt-1',
+        idempotency_key: idempotencyKey,
+        request_hash: requestHash,
+        content: 'Test',
+        lat: 9.0579,
+        lon: 7.4951,
+        location_cell: 's1t7d8c',
+        content_hash: 'cid-1',
+        author: null,
+        author_verified_at: null,
+        stellar_gist_id: '42',
+        tx_hash: 'tx-42',
+        gist_id: null,
+        status: 'chained' as const,
+        created_at: new Date(),
+        updated_at: new Date(),
+      };
+
+      geoService.encode.mockReturnValue('s1t7d8c');
+      ipfsService.pinJson.mockResolvedValue({ cid: 'cid-1', mock: true });
+      sorobanService.postGist.mockResolvedValue({ gistId: '42', txHash: 'tx-42', mock: true });
+      cacheService.delPattern.mockResolvedValue();
+
+      // First attempt: fresh path, then the final DB insert fails.
+      writeAttemptRepository.findByKey.mockResolvedValue(null);
+      writeAttemptRepository.markChained.mockResolvedValue(chainedAttempt);
+      gistRepository.createCommitted.mockRejectedValueOnce(
+        new Error('Postgres briefly unavailable'),
+      );
+
+      await expect(service.create(dto, null, idempotencyKey)).rejects.toThrow(
+        'Postgres briefly unavailable',
+      );
+      expect(sorobanService.postGist).toHaveBeenCalledTimes(1);
+
+      // Retry with the same key: the attempt is now 'chained', so the chain
+      // write is skipped and only the DB insert is retried.
+      writeAttemptRepository.findByKey.mockResolvedValue(chainedAttempt);
+      gistRepository.createCommitted.mockResolvedValueOnce(mockGist());
+
+      const result = await service.create(dto, null, idempotencyKey);
+
+      expect(result).toEqual(mockGist());
+      expect(sorobanService.postGist).toHaveBeenCalledTimes(1); // still once
+      expect(gistRepository.createCommitted).toHaveBeenCalledTimes(2);
+      expect(writeAttemptRepository.markCommitted).toHaveBeenCalledWith(idempotencyKey, 'uuid-1');
+    });
+
+    it('replays a committed attempt without re-posting or re-inserting', async () => {
+      const dto: CreateGistDto = { content: 'Test', lat: 9.0579, lon: 7.4951 };
+      const idempotencyKey = 'key-committed';
+      const committedAttempt = {
+        id: 'attempt-1',
+        idempotency_key: idempotencyKey,
+        request_hash: computeGistRequestHash({ content: 'Test', lat: 9.0579, lon: 7.4951 }),
+        content: 'Test',
+        lat: 9.0579,
+        lon: 7.4951,
+        location_cell: 's1t7d8c',
+        content_hash: 'cid-1',
+        author: null,
+        author_verified_at: null,
+        stellar_gist_id: '42',
+        tx_hash: 'tx-42',
+        gist_id: 'uuid-1',
+        status: 'committed' as const,
+        created_at: new Date(),
+        updated_at: new Date(),
+      };
+      const stored = mockGist();
+
+      writeAttemptRepository.findByKey.mockResolvedValue(committedAttempt);
+      gistRepository.findByGistId.mockResolvedValue(stored);
+
+      const result = await service.create(dto, null, idempotencyKey);
+
+      expect(result).toBe(stored);
+      expect(sorobanService.postGist).not.toHaveBeenCalled();
+      expect(ipfsService.pinJson).not.toHaveBeenCalled();
+      expect(gistRepository.createCommitted).not.toHaveBeenCalled();
+    });
+
+    it('rejects a reused idempotency key that maps to a different request', async () => {
+      const dto: CreateGistDto = { content: 'Test', lat: 9.0579, lon: 7.4951 };
+      const idempotencyKey = 'key-reused';
+      const priorAttempt = {
+        id: 'attempt-1',
+        idempotency_key: idempotencyKey,
+        request_hash: computeGistRequestHash({ content: 'Different', lat: 9.0579, lon: 7.4951 }),
+        content: 'Different',
+        lat: 9.0579,
+        lon: 7.4951,
+        location_cell: 's1t7d8c',
+        content_hash: 'cid-other',
+        author: null,
+        author_verified_at: null,
+        stellar_gist_id: '42',
+        tx_hash: 'tx-42',
+        gist_id: null,
+        status: 'chained' as const,
+        created_at: new Date(),
+        updated_at: new Date(),
+      };
+
+      writeAttemptRepository.findByKey.mockResolvedValue(priorAttempt);
+
+      await expect(service.create(dto, null, idempotencyKey)).rejects.toThrow(
+        UnprocessableEntityException,
+      );
+      expect(sorobanService.postGist).not.toHaveBeenCalled();
     });
   });
 

--- a/Backend/src/gists/gists.service.ts
+++ b/Backend/src/gists/gists.service.ts
@@ -5,11 +5,14 @@ import {
   Injectable,
   Logger,
   NotFoundException,
+  UnprocessableEntityException,
 } from '@nestjs/common';
 import { CreateGistDto } from './dto/create-gist.dto';
 import { QueryGistsDto } from './dto/query-gists.dto';
 import { UpdateGistDto } from './dto/update-gist.dto';
 import { GistRepository } from './gist.repository';
+import { GistWriteAttempt, GistWriteAttemptRepository } from './gist-write-attempt.repository';
+import { computeGistRequestHash } from './idempotency-key.util';
 import { GeoService } from '../geo/geo.service';
 import { IpfsService } from '../ipfs/ipfs.service';
 import { SorobanService } from '../soroban/soroban.service';
@@ -27,18 +30,47 @@ export class GistsService {
 
   constructor(
     private readonly gistRepository: GistRepository,
+    private readonly writeAttemptRepository: GistWriteAttemptRepository,
     private readonly geoService: GeoService,
     private readonly ipfsService: IpfsService,
     private readonly sorobanService: SorobanService,
     private readonly cacheService: CacheService,
   ) {}
 
-  async create(dto: CreateGistDto, stellarVerified?: StellarVerified | null): Promise<Gist> {
+  async create(
+    dto: CreateGistDto,
+    stellarVerified?: StellarVerified | null,
+    idempotencyKey?: string,
+  ): Promise<Gist> {
     // Issue 87 — sanitize content before storing
     const content = stripHtml(dto.content);
 
     const locationCell = this.geoService.encode(dto.lat, dto.lon);
+    const author = stellarVerified ? stellarVerified.address : dto.author;
+    const authorVerifiedAt = stellarVerified ? stellarVerified.verifiedAt : null;
 
+    const requestHash = computeGistRequestHash({
+      content,
+      lat: dto.lat,
+      lon: dto.lon,
+      author,
+    });
+    const key = idempotencyKey ?? requestHash;
+
+    // 1. Resume any prior attempt for the same logical post instead of
+    //    re-pinning and re-posting to the chain.
+    const existing = await this.writeAttemptRepository.findByKey(key);
+    if (existing) {
+      if (existing.request_hash !== requestHash) {
+        throw new UnprocessableEntityException(
+          'Idempotency-Key already used with a different request',
+        );
+      }
+      return this.resumeAttempt(existing);
+    }
+
+    // 2. Pin content to IPFS. Content-addressed, so retrying produces the same
+    //    CID — this step is naturally idempotent.
     const { cid } = await this.ipfsService.pinJson({
       content,
       lat: dto.lat,
@@ -47,30 +79,146 @@ export class GistsService {
       created_at: new Date().toISOString(),
     });
 
-    const author = stellarVerified ? stellarVerified.address : dto.author;
-    const { gistId, txHash } = await this.sorobanService.postGist(locationCell, cid, author);
-
-    this.logger.log(`Gist posted → cell=${locationCell} cid=${cid} gistId=${gistId}`);
-
-    const gist = await this.gistRepository.create({
+    // 3. Durable pending record BEFORE the irreversible on-chain write.
+    const created = await this.writeAttemptRepository.createPending({
+      idempotency_key: key,
+      request_hash: requestHash,
       content,
       lat: dto.lat,
       lon: dto.lon,
       location_cell: locationCell,
       content_hash: cid,
-      stellar_gist_id: gistId,
-      tx_hash: txHash,
-      author,
-      author_verified_at: stellarVerified ? stellarVerified.verifiedAt : null,
+      author: author ?? null,
+      author_verified_at: authorVerifiedAt,
     });
 
+    const pending = created ?? (await this.writeAttemptRepository.findByKey(key));
+    if (pending && pending.status !== 'pending') {
+      // Lost a race — another request already advanced this attempt. Resume it.
+      return this.resumeAttempt(pending);
+    }
+
+    // 4. Irreversible on-chain write.
+    const { gistId, txHash } = await this.sorobanService.postGist(locationCell, cid, author);
+
+    this.logger.log(`Gist posted → cell=${locationCell} cid=${cid} gistId=${gistId}`);
+
+    // 5. Durable record of the chain result, kept separate from the final DB
+    //    insert so a failure between them does not lose the on-chain id.
+    const chained = await this.writeAttemptRepository.markChained(key, gistId, txHash);
+    if (chained === null) {
+      // Another request advanced (or removed) this attempt while we were on
+      // the chain. Re-read and resume instead of re-inserting blindly.
+      const attempt = await this.writeAttemptRepository.findByKey(key);
+      if (attempt) {
+        return this.resumeAttempt(attempt);
+      }
+    }
+
+    return this.persistAndCommit(
+      {
+        idempotency_key: key,
+        content,
+        lat: dto.lat,
+        lon: dto.lon,
+        location_cell: locationCell,
+        content_hash: cid,
+        author: author ?? null,
+        author_verified_at: authorVerifiedAt,
+      },
+      gistId,
+      txHash,
+    );
+  }
+
+  /**
+   * Finishes a prior attempt without re-posting to the chain.
+   *
+   * - `committed` → return the already-persisted gist.
+   * - `chained`   → the chain write already happened; only the DB insert remains.
+   * - `pending`   → no durable evidence the chain write happened, so it is re-submitted.
+   */
+  private async resumeAttempt(attempt: GistWriteAttempt): Promise<Gist> {
+    if (attempt.status === 'committed') {
+      if (attempt.gist_id) {
+        const gist = await this.gistRepository.findByGistId(attempt.gist_id);
+        if (gist) {
+          return gist;
+        }
+      }
+      // `committed` implies the gists row exists; if it was pruned, fall through
+      // to the idempotent insert rather than minting a second on-chain gist.
+      return this.finishChained(attempt);
+    }
+
+    if (attempt.status === 'chained') {
+      return this.finishChained(attempt);
+    }
+
+    // 'pending' — resume from the already-pinned CID.
+    const locationCell = attempt.location_cell ?? this.geoService.encode(attempt.lat, attempt.lon);
+    const { gistId, txHash } = await this.sorobanService.postGist(
+      locationCell,
+      attempt.content_hash ?? '',
+      attempt.author ?? undefined,
+    );
+
+    this.logger.log(
+      `Gist re-posted (pending resume) → cell=${locationCell} cid=${attempt.content_hash} gistId=${gistId}`,
+    );
+
+    await this.writeAttemptRepository.markChained(attempt.idempotency_key, gistId, txHash);
+    return this.persistAndCommit(attempt, gistId, txHash);
+  }
+
+  private async finishChained(attempt: GistWriteAttempt): Promise<Gist> {
+    if (!attempt.stellar_gist_id) {
+      throw new Error(
+        `gist_write_attempt ${attempt.id} is ${attempt.status} but has no stellar_gist_id`,
+      );
+    }
+    return this.persistAndCommit(attempt, attempt.stellar_gist_id, attempt.tx_hash ?? '');
+  }
+
+  private async persistAndCommit(
+    attempt: Pick<
+      GistWriteAttempt,
+      | 'idempotency_key'
+      | 'content'
+      | 'lat'
+      | 'lon'
+      | 'location_cell'
+      | 'content_hash'
+      | 'author'
+      | 'author_verified_at'
+    >,
+    gistId: string,
+    txHash: string,
+  ): Promise<Gist> {
+    const gist = await this.gistRepository.createCommitted({
+      content: attempt.content,
+      lat: attempt.lat,
+      lon: attempt.lon,
+      location_cell: attempt.location_cell ?? undefined,
+      content_hash: attempt.content_hash ?? undefined,
+      stellar_gist_id: gistId,
+      tx_hash: txHash,
+      author: attempt.author ?? undefined,
+      author_verified_at: attempt.author_verified_at ?? null,
+    });
+
+    await this.writeAttemptRepository.markCommitted(attempt.idempotency_key, gist.id);
+
     // Invalidate nearby cache for the affected area
-    await this.invalidateNearbyCache(dto.lat, dto.lon);
+    await this.invalidateNearbyCache(attempt.lat, attempt.lon);
 
     return gist;
   }
 
-  async createBatch(dtos: CreateGistDto[], stellarVerified?: StellarVerified | null): Promise<Gist[]> {
+  async createBatch(
+    dtos: CreateGistDto[],
+    stellarVerified?: StellarVerified | null,
+  ): Promise<Gist[]> {
     const createdAt = new Date().toISOString();
     const author = stellarVerified ? stellarVerified.address : undefined;
     const authorVerifiedAt = stellarVerified ? stellarVerified.verifiedAt : null;

--- a/Backend/src/gists/idempotency-key.util.ts
+++ b/Backend/src/gists/idempotency-key.util.ts
@@ -1,0 +1,25 @@
+import { createHash } from 'crypto';
+
+/**
+ * Deterministic fingerprint of a gist create request.
+ *
+ * Stable across retries of the same logical post, so the write path can
+ * recognize a replay even when the client omits an `Idempotency-Key` header.
+ * The payload is canonicalized (author normalized to `null`) before hashing so
+ * two retries of the same anonymous post produce the same value.
+ */
+export function computeGistRequestHash(payload: {
+  content: string;
+  lat: number;
+  lon: number;
+  author?: string | null;
+}): string {
+  const canonical = JSON.stringify({
+    content: payload.content,
+    lat: payload.lat,
+    lon: payload.lon,
+    author: payload.author ?? null,
+  });
+
+  return createHash('sha256').update(canonical).digest('hex');
+}

--- a/Frontend/src/api/gists.test.ts
+++ b/Frontend/src/api/gists.test.ts
@@ -38,6 +38,31 @@ describe('postGist', () => {
     expect(options.headers['Content-Type']).toBe('application/json');
   });
 
+  it('should send an Idempotency-Key header on every post', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockResponse),
+    });
+
+    await postGist(validPayload);
+
+    const [, options] = mockFetch.mock.calls[0];
+    expect(typeof options.headers['Idempotency-Key']).toBe('string');
+    expect(options.headers['Idempotency-Key'].length).toBeGreaterThan(0);
+  });
+
+  it('should reuse a caller-supplied idempotency key', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockResponse),
+    });
+
+    await postGist(validPayload, { idempotencyKey: 'key-123' });
+
+    const [, options] = mockFetch.mock.calls[0];
+    expect(options.headers['Idempotency-Key']).toBe('key-123');
+  });
+
   it('should return the server-confirmed gist on success', async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,

--- a/Frontend/src/api/gists.ts
+++ b/Frontend/src/api/gists.ts
@@ -32,18 +32,43 @@ export class GistApiError extends Error {
 const BASE_URL =
   process.env.NEXT_PUBLIC_API_URL || "http://localhost:3000";
 
+export interface PostGistOptions {
+  /**
+   * Stable key reused across retries of the same logical post so the backend
+   * can deduplicate a mid-write failure instead of minting a second gist.
+   */
+  idempotencyKey?: string;
+}
+
+function generateIdempotencyKey(): string {
+  const c = globalThis.crypto as { randomUUID?: () => string } | undefined;
+  if (c && typeof c.randomUUID === "function") {
+    return c.randomUUID();
+  }
+  return `${Date.now()}-${Math.random().toString(36).slice(2)}-${Math.random()
+    .toString(36)
+    .slice(2)}`;
+}
+
 /**
  * POST a new gist to the backend.
  *
  * Returns the server-confirmed gist on success.
  * Throws a {@link GistApiError} on network failure or non-2xx response.
  */
-export async function postGist(payload: GistPayload): Promise<GistResponse> {
+export async function postGist(
+  payload: GistPayload,
+  options: PostGistOptions = {},
+): Promise<GistResponse> {
   const url = `${BASE_URL}/gists`;
+  const idempotencyKey = options.idempotencyKey ?? generateIdempotencyKey();
 
   const res = await fetch(url, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: {
+      "Content-Type": "application/json",
+      "Idempotency-Key": idempotencyKey,
+    },
     body: JSON.stringify(payload),
   });
 

--- a/infrastructure/docker/postgres.Dockerfile
+++ b/infrastructure/docker/postgres.Dockerfile
@@ -7,15 +7,18 @@
 # when the image is built as part of a `docker buildx` multi-arch build.
 #
 # Security: gosu is rebuilt from source against a patched Go toolchain to
-# remediate CVE-2026-42504 in the binary shipped with the upstream image.
+# remediate the Go stdlib CVEs (CVE-2026-33818, CVE-2026-39821,
+# CVE-2026-46600, CVE-2026-56853, CVE-2026-56858, CVE-2026-56859,
+# CVE-2026-56860, CVE-2026-56862) in the binary shipped with the upstream image.
 #
 # BUILDPLATFORM and TARGETPLATFORM are automatic ARGs injected by Buildx —
 # do NOT declare them manually, that overrides them with empty strings.
 # See: https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope
 
-# Stage 1: Build gosu with a patched Go version to fix CVE-2026-42504.
-# Run on BUILDPLATFORM so the Go compiler executes natively (no QEMU).
-FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine AS gosu-builder
+# Stage 1: Build gosu with a patched Go version (1.26.6) to remediate the
+# Go stdlib CVEs above. Run on BUILDPLATFORM so the Go compiler executes
+# natively (no QEMU).
+FROM --platform=$BUILDPLATFORM golang:1.26.6-alpine AS gosu-builder
 RUN apk add --no-cache git
 WORKDIR /go/src/github.com/tianon/gosu
 RUN git clone https://github.com/tianon/gosu.git . && \


### PR DESCRIPTION
## Summary

Closes #427

`GistsService.create` now records a durable write attempt (`pending → chained → committed`) in a new `gist_write_attempts` table *before* the irreversible Soroban call, and records the on-chain result (`stellar_gist_id`/`tx_hash`) in a separate step from the final Postgres insert. A client that retries after a mid-write DB failure therefore resumes the already-chained gist instead of minting a second on-chain record. The final insert is idempotent (`ON CONFLICT (stellar_gist_id)`), and the missing unique index that `upsertFromEvent` already assumed is added. The idempotency middleware now records failed attempts, and the frontend sends an `Idempotency-Key` header.

## Why

The previous write path had no shared transaction across IPFS, Soroban, and Postgres: `pinJson` → `postGist` (irreversible) → `gistRepository.create` (last, and the only durable record). If the insert failed, the client retried all three steps and produced a second on-chain gist and a second IPFS pin. The existing idempotency middleware only stored the response inside the overridden `res.json` (success path), so a failed request left no `Idempotency-Key` for the retry to match, and the frontend sent no header at all.

The fix closes that gap with a durable ledger keyed by the idempotency key, written *before* the chain call and advanced to `chained` as soon as the on-chain id is known. That ordering means the named failure mode (insert fails after the chain write succeeds) is recoverable by a plain retry with no second chain write — the key design decision, since it avoids reordering to a pending-flag-on-`gists` design that would leak uncommitted rows into `findNearby` and require touching every read path.

## What was built

`Backend/src/gists/` (new files):

| File | What it contains |
|---|---|
| `gist-write-attempt.repository.ts` | Durable `gist_write_attempts` repository (raw SQL) with `findByKey`, `createPending` (`ON CONFLICT (idempotency_key) DO NOTHING`), `markChained` (only advances `pending`), `markCommitted`. Defines the `GistWriteAttempt` type and the `pending/chained/committed` state machine. |
| `idempotency-key.util.ts` | `computeGistRequestHash` — canonical, deterministic SHA-256 fingerprint of `{content, lat, lon, author}` used as both the fallback idempotency key and the `request_hash` reuse check. |

`Backend/src/database/migrations/1700000000004-AddGistWriteAttempts.ts` (new): creates `gist_write_attempts` and adds `UQ_gists_stellar_gist_id` (the unique index `upsertFromEvent`/`createCommitted` require).

Matching tests: `gists.service.spec.ts` (3 new), `idempotency.middleware.spec.ts` (2 new), `gists.controller.spec.ts` (1 new).

## Integration changes outside the new files

- **`Backend/src/gists/gists.service.ts`** — `create(dto, stellarVerified, idempotencyKey?)` now runs the resume state machine; added `resumeAttempt`/`finishChained`/`persistAndCommit`.
- **`Backend/src/gists/gist.repository.ts`** — added `createCommitted` (`ON CONFLICT (stellar_gist_id) DO NOTHING` + re-read on conflict).
- **`Backend/src/gists/entities/gist.entity.ts`** — named the `stellar_gist_id` unique index `UQ_gists_stellar_gist_id` so entity and migration stay in sync.
- **`Backend/src/gists/gists.controller.ts`** — forwards the `Idempotency-Key` header to the service.
- **`Backend/src/gists/gists.module.ts`** — registers `GistWriteAttemptRepository`.
- **`Backend/src/common/middleware/idempotency.middleware.ts`** — stores `state: done|failed`; records `failed` entries on error statuses and lets a matching retry proceed instead of replaying the error (legacy entries without `state` are treated as `done`).
- **`Frontend/src/api/gists.ts`** — generates and sends an `Idempotency-Key` header (caller-overridable for retries).
- **`Backend/README.md`** — documents the idempotency contract and the ledger table.

## Acceptance criteria coverage

### Contract
- [x] A client that retries a `POST /gists` after a mid-write failure does not produce a second on-chain gist for the same logical post. (`gists.service.spec.ts` — "does not re-post to the chain when a retry follows a failed DB insert" asserts `postGist` is called exactly once across the failed attempt and its retry; the frontend now sends a stable `Idempotency-Key` so the retry is recognized.)

### Service
- [x] A simulated failure between the chain write and the DB insert leaves the system in a state the indexer or a later retry reconciles, without a duplicate record. (The `markChained` step durably records `stellar_gist_id` before the final insert; on retry `resumeAttempt` sees `chained` and finishes the insert via idempotent `createCommitted` — asserted by the same test, plus `UQ_gists_stellar_gist_id` enforces no duplicate row at the DB layer.)

### Tests
- [x] A unit test drives `create` with `gistRepository.create` rejecting and asserts the write path is either compensated or idempotent. (The final DB insert is now `gistRepository.createCommitted`; the test rejects that method on the first attempt and asserts the retry is idempotent — `gists.service.spec.ts`.)
- [x] A test asserts the idempotency middleware records a failed attempt (or otherwise prevents replay). (`idempotency.middleware.spec.ts` — "records a failed attempt when the handler responds with an error status" and "allows a retry to proceed after a failed attempt instead of replaying the error".)

## Deliberately deferred

- **Indexer reconciliation of crash-window orphans.** If the process dies between `postGist` and `markChained`, the attempt stays `pending` with no on-chain id and a retry re-posts. The issue's proposed design names the indexer as the reconciler for this case, but doing so needs a chain read by content hash (`list_gists_by_cell`) that `SorobanService` does not expose yet (mock `getEventsSince` returns `[]`). The acceptance criteria's "indexer or a later retry" is satisfied via the later-retry path for the named failure mode. Open to aligning on the chain-read seam before building this.
- **Durable per-item idempotency for `POST /gists/batch`.** The acceptance criteria target `POST /gists` (singular) only. Batch still receives the generic middleware `Idempotency-Key` semantics (including failed-attempt recording), but per-item durable reconciliation would need a per-item key scheme that is not specified in the issue.

## Test plan

- [x] `CI=true npm test -- --runInBand` (Backend) — 186 passed, 13 skipped (199 total); 6 new tests for this feature
- [x] `npx tsc --noEmit` (Backend) — no type errors
- [x] `npx eslint` on changed files (Backend) — 0 errors, 0 warnings
- [x] `npm run build` (Backend) — succeeds
- [x] `npm run test` (Frontend) — 82 passed (14 files); 2 new tests
- [x] `npm run lint` (Frontend) — exits 0 (one pre-existing `<img>` warning in `Features.test.tsx`, unrelated)
- [x] `npm run build` (Frontend) — succeeds
- [ ] Manual: run `migration:run` against a real Postgres and confirm `gist_write_attempts` + `UQ_gists_stellar_gist_id` are created

## Env vars / Notes

```env
IDEMPOTENCY_TTL_SECONDS=86400   # TTL for middleware idempotency cache entries (unchanged, pre-existing)
```

- The middleware's cached entry shape gained a `state` field; entries written before this change are treated as completed (`done`), so there is no replay regression during the cache TTL.
- The migration adds a unique index on `gists.stellar_gist_id`. Precondition: no existing duplicate non-NULL `stellar_gist_id` rows (none expected — `upsertFromEvent` could not dedup without it).
- `createBatch` was reformatted by prettier (line wrapping only) — no behavior change.