### PR TITLE
fix(indexer): advance cursor by ledger sequence, not timestamp

### DIFF
--- a/Backend/src/indexer/indexer.service.spec.ts
+++ b/Backend/src/indexer/indexer.service.spec.ts
@@ -1,0 +1,101 @@
+import * as fs from 'fs';
+import { IndexerService } from './indexer.service';
+import { SorobanService, GistEvent } from '../soroban/soroban.service';
+import { GistRepository } from '../gists/gist.repository';
+import { GeoService } from '../geo/geo.service';
+
+const fakeEvent = (overrides: Partial<GistEvent> = {}): GistEvent => ({
+  gistId: 'g1',
+  locationCell: 's1t7d8c',
+  contentHash: 'cid-1',
+  author: null,
+  ledger: 1000,
+  createdAt: 1710000000,
+  ...overrides,
+});
+
+describe('IndexerService', () => {
+  let soroban: jest.Mocked<SorobanService>;
+  let gistRepository: jest.Mocked<GistRepository>;
+  let geoService: jest.Mocked<GeoService>;
+
+  beforeEach(() => {
+    soroban = { getEventsSince: jest.fn() } as unknown as jest.Mocked<SorobanService>;
+    gistRepository = {
+      upsertFromEvent: jest.fn(),
+    } as unknown as jest.Mocked<GistRepository>;
+    geoService = { decode: jest.fn() } as unknown as jest.Mocked<GeoService>;
+
+    geoService.decode.mockReturnValue({ lat: 9.0579, lon: 7.4951 });
+    gistRepository.upsertFromEvent.mockResolvedValue({ id: 'uuid' } as never);
+
+    // Keep the cursor persistence in-memory for tests.
+    jest.spyOn(fs, 'writeFileSync').mockImplementation(() => undefined);
+    jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  const makeService = () => new IndexerService(soroban, gistRepository, geoService);
+
+  it('advances the cursor by event.ledger and keeps created_at from event.createdAt', async () => {
+    soroban.getEventsSince.mockResolvedValue([
+      fakeEvent({ gistId: 'onchain-1', ledger: 1000, createdAt: 1710000000 }),
+    ]);
+
+    const service = makeService();
+    await (service as any).poll();
+
+    expect(fs.writeFileSync).toHaveBeenCalledWith(expect.any(String), '1000');
+    expect((service as any).lastProcessedLedger).toBe(1000);
+    expect(gistRepository.upsertFromEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stellar_gist_id: 'onchain-1',
+        created_at: new Date(1710000000 * 1000),
+      }),
+    );
+  });
+
+  it('resumes from the persisted ledger sequence after a restart, not a timestamp', async () => {
+    soroban.getEventsSince.mockResolvedValue([
+      fakeEvent({ gistId: 'onchain-1', ledger: 1000, createdAt: 1710000000 }),
+    ]);
+
+    const first = makeService();
+    await (first as any).poll();
+    expect(fs.writeFileSync).toHaveBeenCalledWith(expect.any(String), '1000');
+
+    // Simulate a restart: the cursor file now contains the sequence "1000".
+    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+    jest.spyOn(fs, 'readFileSync').mockReturnValue('1000' as never);
+
+    const restarted = makeService();
+    (restarted as any).loadCursor();
+    expect((restarted as any).lastProcessedLedger).toBe(1000);
+
+    soroban.getEventsSince.mockResolvedValue([]);
+    await (restarted as any).poll();
+    expect(soroban.getEventsSince).toHaveBeenLastCalledWith(1000);
+  });
+
+  it('does not advance the cursor past a failed upsert', async () => {
+    const ok = fakeEvent({ gistId: 'ok', ledger: 100, createdAt: 1710000000 });
+    const fail = fakeEvent({ gistId: 'fail', ledger: 200, createdAt: 1710000060 });
+    const skipped = fakeEvent({ gistId: 'skipped', ledger: 300, createdAt: 1710000120 });
+    soroban.getEventsSince.mockResolvedValue([ok, fail, skipped]);
+
+    gistRepository.upsertFromEvent
+      .mockResolvedValueOnce({ id: 'uuid-ok' } as never)
+      .mockRejectedValueOnce(new Error('db down'));
+
+    const service = makeService();
+    await (service as any).poll();
+
+    expect((service as any).lastProcessedLedger).toBe(100);
+    expect(fs.writeFileSync).toHaveBeenCalledWith(expect.any(String), '100');
+    // ok + fail were attempted; the event after the failure was not.
+    expect(gistRepository.upsertFromEvent).toHaveBeenCalledTimes(2);
+  });
+});

--- a/Backend/src/indexer/indexer.service.ts
+++ b/Backend/src/indexer/indexer.service.ts
@@ -87,17 +87,22 @@ export class IndexerService implements OnModuleInit, OnModuleDestroy {
             created_at: new Date(event.createdAt * 1000),
           });
 
-          maxLedger = Math.max(maxLedger, event.createdAt);
+          maxLedger = Math.max(maxLedger, event.ledger);
           indexedCount++;
 
           this.logger.debug(
-            `Indexed gist ${event.gistId} @ cell ${event.locationCell} (ledger ${event.createdAt})`,
+            `Indexed gist ${event.gistId} @ cell ${event.locationCell} (ledger ${event.ledger})`,
           );
         } catch (eventErr) {
           this.logger.error(
             `Failed to index event for gist ${event.gistId} @ cell ${event.locationCell}`,
             eventErr,
           );
+          // Stop advancing the cursor at the first failure. Events are assumed
+          // to be returned in ledger order, so retrying from here on the next
+          // poll re-delivers this event and everything after it. Advancing past
+          // a failed upsert would permanently skip that gist.
+          break;
         }
       }
 


### PR DESCRIPTION
## Summary

Closes #422

`IndexerService.poll()` advanced its ledger cursor with `event.createdAt` (a unix timestamp) instead of `event.ledger` (the Soroban ledger sequence). This fix swaps the cursor to `event.ledger` while leaving `created_at` (the Postgres timestamp) derived from `event.createdAt`, and stops advancing the cursor at the first failed upsert so a transient failure is retried on the next poll instead of being skipped.

## Why

`GistEvent` carries two independent fields — `ledger` (sequence) and `createdAt` (unix seconds). The indexer used `createdAt` for both purposes: `upsertFromEvent` correctly does `new Date(event.createdAt * 1000)`, but `maxLedger = Math.max(maxLedger, event.createdAt)` wrote a timestamp into `.indexer-cursor`. A unix timestamp is orders of magnitude larger than any real ledger sequence, so after a restart `getEventsSince(<timestamp>)` resumed from a ledger that does not exist yet and silently indexed nothing. Separating the two uses (sequence for the cursor, timestamp for `created_at`) is the minimal correct fix.

The additional `break` on a failed upsert closes a second gap the acceptance criteria call out: without it, a later successful event could advance the cursor past a failed one and permanently skip that gist.

## What was built

`Backend/src/indexer/indexer.service.ts`:

| Change | Effect |
|---|---|
| `maxLedger = Math.max(maxLedger, event.ledger)` | cursor advances by ledger sequence |
| debug log prints `event.ledger` | cursor semantics in logs match the sequence |
| `break` in the upsert catch | cursor never advances past an unindexed event |

`created_at` derivation is unchanged (`new Date(event.createdAt * 1000)`).

`Backend/src/indexer/indexer.service.spec.ts` (new, 3 tests): drives the private `poll()`/`loadCursor()` with fake `GistEvent`s, using `fs` spies so the `.indexer-cursor` round-trip is exercised without touching the real filesystem.

## Integration changes outside the new file

- **`Backend/src/indexer/indexer.service.ts`** — 7 lines changed (cursor expression, debug log, and the `break`). No public API, ABI, or `.indexer-cursor` file-format change.

## Acceptance criteria coverage

### Contract
- [x] `lastProcessedLedger` advances by `event.ledger` (the ledger sequence), never by `event.createdAt`. (`indexer.service.spec.ts` — "advances the cursor by event.ledger…" asserts the cursor is saved as `1000` while the event's `createdAt` is `1710000000`.)
- [x] `created_at` written to Postgres remains derived from `event.createdAt` (a timestamp), unchanged. (Same test asserts `upsertFromEvent` receives `created_at: new Date(1710000000 * 1000)`.)

### Service
- [x] A simulated restart (persist cursor, re-run `onModuleInit`, poll again) resumes from the last processed ledger sequence, not a timestamp. (`indexer.service.spec.ts` — "resumes from the persisted ledger sequence after a restart…" persists `1000`, re-loads it via `loadCursor()`, and asserts the next `getEventsSince` is called with `1000`. The test calls `loadCursor()` directly rather than `onModuleInit()` to avoid starting the background polling interval; `loadCursor` is exactly the cursor-restore portion of `onModuleInit`.)

### Tests
- [x] A new unit test passes a fake `GistEvent` with `ledger = 1000` and `createdAt = 1710000000` and asserts the saved cursor is `1000`. (`indexer.service.spec.ts`)
- [x] A test asserts a failed upsert does not advance the cursor past that event's ledger. (`indexer.service.spec.ts` — "does not advance the cursor past a failed upsert": events `[100, 200, 300]` with `200` failing leaves the cursor at `100` and attempts only 2 upserts.)

## Test plan

- [x] `CI=true npm test -- --runInBand` (Backend) — 183 passed, 13 skipped (196 total); 3 new tests for this feature
- [x] `npx tsc --noEmit` (Backend) — no type errors
- [x] `npx eslint` on changed files (Backend) — 0 errors, 0 warnings
- [x] `npm run build` (Backend) — succeeds
- [ ] Manual: run against a real Soroban RPC emitting events with distinct ledger/createdAt (the real `getEventsSince` RPC call is not implemented, out of scope)

## Env vars / Notes

- No new env vars or config. The `.indexer-cursor` file format is unchanged (a bare decimal string), so existing cursors remain compatible.
- Cursors previously written as timestamps (by the bug) cannot be mapped back to a ledger sequence; for affected deployments the one-time remedy is to reset the file (delete it or set `0`), after which the indexer resumes from the correct ledger.