### PR TITLE
fix(gists): require verified Stellar signature for authorship

### DIFF
--- a/Backend/README.md
+++ b/Backend/README.md
@@ -166,7 +166,7 @@ Content-Type: application/json
 }
 ```
 
-`authorAddress` is optional — anonymous posting is fully supported.
+Posting is fully anonymous by default: a gist's `author` is set only from a verified Stellar signature (`X-Stellar-Address` / `X-Stellar-Signature` / `X-Stellar-Timestamp` headers, as in `PATCH /gists/:id`). An unsigned `author` body field is ignored, so a gist cannot be attributed to an address the caller does not control.
 
 **Idempotency.** Send an `Idempotency-Key` header (any unique string, e.g. a UUID) on every post. The server records a durable write attempt *before* the irreversible on-chain call and replays it on retry, so a client that retries after a mid-write failure gets the original gist instead of a second on-chain record. If the header is omitted, the server derives a deterministic key from the request content, so identical retries still deduplicate. Reusing a key with a *different* body returns `422`.
 
@@ -184,19 +184,28 @@ Content-Type: application/json
 ```
 PATCH /gists/{id}
 Content-Type: application/json
+X-Stellar-Address: GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+X-Stellar-Signature: <64-byte Ed25519 signature, hex>
+X-Stellar-Timestamp: <unix seconds>
 ```
 
 ```json
 {
-  "content": "Great street food here tonight (fixed typo)",
-  "author": "GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+  "content": "Great street food here tonight (fixed typo)"
 }
 ```
 
+Editing now requires a Stellar signature that covers the request body. The
+`X-Stellar-Signature` header is an Ed25519 signature over
+`<timestamp>.<sha256(canonical body)>`, verified against the
+`X-Stellar-Address` public key. The body `author` field is deprecated and ignored —
+authorship comes only from the verified signature.
+
 Lets an author fix a typo shortly after posting — but only shortly after:
 
+- **Signature-gated.** Missing or invalid `X-Stellar-*` headers return `401 Unauthorized`.
 - **60-second edit window.** Measured from the gist's `created_at`. Once elapsed, the endpoint returns `410 Gone` and the content is permanent.
-- **Author-gated.** `author` must match the gist's stored author exactly, or the endpoint returns `403 Forbidden`. Gists posted without an author (fully anonymous) can never be edited — there's no identity to verify against.
+- **Author-gated.** The verified address must match the gist's stored author exactly, or the endpoint returns `403 Forbidden`. Gists posted without a verified signature are stored with `author = null` and can never be edited — there's no identity to verify against.
 - **Lineage preserved.** The prior IPFS CID is kept in `previous_cid` and the new content is re-pinned to IPFS, producing a fresh `content_hash`. Nothing is deleted — the edit is an append, not an overwrite of history.
 
 ---

--- a/Backend/src/gists/dto/update-gist.dto.ts
+++ b/Backend/src/gists/dto/update-gist.dto.ts
@@ -1,5 +1,5 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { IsString, MaxLength } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsString, MaxLength } from 'class-validator';
 
 export class UpdateGistDto {
   @ApiProperty({
@@ -11,11 +11,13 @@ export class UpdateGistDto {
   @MaxLength(280)
   content: string;
 
-  @ApiProperty({
-    description: "Stellar address of the gist's original author; must match the stored author",
+  @ApiPropertyOptional({
+    description:
+      'Deprecated: the author is now derived from the X-Stellar-* signature headers. This field is accepted for compatibility but ignored.',
     example: 'GABC...XYZ',
   })
+  @IsOptional()
   @IsString()
   @MaxLength(80)
-  author: string;
+  author?: string;
 }

--- a/Backend/src/gists/gists.controller.spec.ts
+++ b/Backend/src/gists/gists.controller.spec.ts
@@ -256,43 +256,45 @@ describe('GistsController', () => {
   });
 
   describe('update()', () => {
-    it('should call gistsService.update with the id and DTO', async () => {
+    const verified = { address: 'GABC...XYZ', verifiedAt: new Date() };
+
+    it('should call gistsService.update with the id, DTO, and verified user', async () => {
       const id = '123e4567-e89b-12d3-a456-426614174000';
-      const dto: UpdateGistDto = { content: 'Fixed typo', author: 'GABC...XYZ' };
-      const result = createMockGist({ id, content: dto.content, author: dto.author });
+      const dto: UpdateGistDto = { content: 'Fixed typo' };
+      const result = createMockGist({ id, content: dto.content, author: verified.address });
 
       jest.spyOn(service, 'update').mockResolvedValueOnce(result);
 
-      const response = await controller.update(id, dto);
+      const response = await controller.update(id, dto, verified);
 
-      expect(service.update).toHaveBeenCalledWith(id, dto);
+      expect(service.update).toHaveBeenCalledWith(id, dto, verified);
       expect(response).toEqual(result);
     });
 
     it('should propagate a 410 Gone error when the edit window has closed', async () => {
       const id = '123e4567-e89b-12d3-a456-426614174000';
-      const dto: UpdateGistDto = { content: 'Fixed typo', author: 'GABC...XYZ' };
+      const dto: UpdateGistDto = { content: 'Fixed typo' };
       const error = Object.assign(new Error('Edit window has closed for this gist'), {
         status: 410,
       });
 
       jest.spyOn(service, 'update').mockRejectedValueOnce(error);
 
-      await expect(controller.update(id, dto)).rejects.toThrow(
+      await expect(controller.update(id, dto, verified)).rejects.toThrow(
         'Edit window has closed for this gist',
       );
     });
 
-    it('should propagate a forbidden error when the author does not match', async () => {
+    it('should propagate a forbidden error when the signed address does not match', async () => {
       const id = '123e4567-e89b-12d3-a456-426614174000';
-      const dto: UpdateGistDto = { content: 'Fixed typo', author: 'GIMPOSTOR' };
+      const dto: UpdateGistDto = { content: 'Fixed typo' };
       const error = Object.assign(new Error('Only the original author may edit this gist'), {
         status: 403,
       });
 
       jest.spyOn(service, 'update').mockRejectedValueOnce(error);
 
-      await expect(controller.update(id, dto)).rejects.toThrow(
+      await expect(controller.update(id, dto, verified)).rejects.toThrow(
         'Only the original author may edit this gist',
       );
     });

--- a/Backend/src/gists/gists.controller.ts
+++ b/Backend/src/gists/gists.controller.ts
@@ -13,7 +13,7 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { Throttle, SkipThrottle } from '@nestjs/throttler';
-import { ApiBody, ApiOperation, ApiTags, ApiParam, ApiResponse } from '@nestjs/swagger';
+import { ApiBody, ApiHeader, ApiOperation, ApiTags, ApiParam, ApiResponse } from '@nestjs/swagger';
 import { GistsService } from './gists.service';
 import { CreateGistDto } from './dto/create-gist.dto';
 import { QueryGistsDto } from './dto/query-gists.dto';
@@ -86,14 +86,35 @@ export class GistsController {
   }
 
   @Patch(':id')
+  @UseGuards(StellarAuthGuard)
   @Throttle({ default: { limit: 10, ttl: 60000 } })
   @ApiOperation({
-    summary: 'Correct a gist within its 60s edit window (same author only)',
+    summary: 'Correct a gist within its 60s edit window (signed author only)',
   })
   @ApiParam({ name: 'id', description: 'Gist UUID' })
-  @ApiResponse({ status: 403, description: 'Caller is not the original author' })
+  @ApiHeader({
+    name: 'X-Stellar-Address',
+    required: true,
+    description: "Editor's Stellar public key (G...)",
+  })
+  @ApiHeader({
+    name: 'X-Stellar-Signature',
+    required: true,
+    description: 'Ed25519 signature (hex) over `<timestamp>.<sha256(canonical body)>`',
+  })
+  @ApiHeader({
+    name: 'X-Stellar-Timestamp',
+    required: true,
+    description: 'Unix seconds; must be within the replay window',
+  })
+  @ApiResponse({ status: 401, description: 'Missing or invalid Stellar signature headers' })
+  @ApiResponse({ status: 403, description: 'Signed address is not the original author' })
   @ApiResponse({ status: 410, description: 'Edit window has closed' })
-  update(@Param('id') id: string, @Body() dto: UpdateGistDto) {
-    return this.gistsService.update(id, dto);
+  update(
+    @Param('id') id: string,
+    @Body() dto: UpdateGistDto,
+    @StellarVerifiedUser() stellarVerified: StellarVerified | null,
+  ) {
+    return this.gistsService.update(id, dto, stellarVerified);
   }
 }

--- a/Backend/src/gists/gists.service.spec.ts
+++ b/Backend/src/gists/gists.service.spec.ts
@@ -14,8 +14,10 @@ import { UpdateGistDto } from './dto/update-gist.dto';
 import {
   ForbiddenException,
   NotFoundException,
+  UnauthorizedException,
   UnprocessableEntityException,
 } from '@nestjs/common';
+import { StellarVerified } from '../auth/interfaces/stellar-verified.interface';
 
 jest.mock('../common/utils/sanitize', () => ({
   stripHtml: jest.fn((text: string) => text),
@@ -135,8 +137,9 @@ describe('GistsService', () => {
         expect.objectContaining({ content: 'First', location_cell: 'cell-1' }),
         expect.objectContaining({ content: 'Second', location_cell: 'cell-2' }),
       ]);
-      expect(sorobanService.postGist).toHaveBeenNthCalledWith(1, 'cell-1', 'cid-1', undefined);
-      expect(sorobanService.postGist).toHaveBeenNthCalledWith(2, 'cell-2', 'cid-2', 'GABC');
+      // An unsigned `author` body field is ignored: both items are anonymous.
+      expect(sorobanService.postGist).toHaveBeenNthCalledWith(1, 'cell-1', 'cid-1', null);
+      expect(sorobanService.postGist).toHaveBeenNthCalledWith(2, 'cell-2', 'cid-2', null);
     });
   });
 
@@ -174,7 +177,7 @@ describe('GistsService', () => {
       );
     });
 
-    it('calls SorobanService.postGist with locationCell, cid, and author', async () => {
+    it('ignores an unsigned author body field and posts anonymously', async () => {
       const dto: CreateGistDto = { content: 'Test', lat: 9.0579, lon: 7.4951, author: 'GABC' };
       geoService.encode.mockReturnValue('s1t7d8c');
       ipfsService.pinJson.mockResolvedValue({ cid: 'mock_Qmabc', mock: true });
@@ -184,7 +187,7 @@ describe('GistsService', () => {
 
       await service.create(dto);
 
-      expect(sorobanService.postGist).toHaveBeenCalledWith('s1t7d8c', 'mock_Qmabc', 'GABC');
+      expect(sorobanService.postGist).toHaveBeenCalledWith('s1t7d8c', 'mock_Qmabc', null);
     });
 
     it('calls GistRepository.createCommitted with all required fields', async () => {
@@ -411,7 +414,7 @@ describe('GistsService', () => {
       geoService.encode.mockReturnValue('s1t7d8c');
       ipfsService.pinJson.mockResolvedValue({ cid: 'mock_Qmabc', mock: true });
       sorobanService.postGist.mockResolvedValue({ gistId: '1', txHash: 'tx1', mock: true });
-      gistRepository.create.mockResolvedValue(mockGist());
+      gistRepository.createCommitted.mockResolvedValue(mockGist());
       cacheService.delPattern.mockResolvedValue();
 
       await service.create({ content: 'Test', lat, lon });
@@ -460,29 +463,49 @@ describe('GistsService', () => {
   });
 
   describe('update()', () => {
-    const dto: UpdateGistDto = { content: 'Fixed typo', author: 'GABC' };
+    const dto: UpdateGistDto = { content: 'Fixed typo' };
+    const verified = (address: string): StellarVerified => ({
+      address,
+      verifiedAt: new Date(),
+    });
 
     it('throws NotFoundException when gist does not exist', async () => {
       gistRepository.findByGistId.mockResolvedValue(null);
 
-      await expect(service.update('missing', dto)).rejects.toThrow(NotFoundException);
+      await expect(service.update('missing', dto, verified('GABC'))).rejects.toThrow(
+        NotFoundException,
+      );
     });
 
     it('throws 410 Gone when the 60s edit window has closed', async () => {
       const gist = mockGist({ created_at: new Date(Date.now() - 61_000) });
       gistRepository.findByGistId.mockResolvedValue(gist);
 
-      await expect(service.update('uuid-1', dto)).rejects.toMatchObject({
+      await expect(service.update('uuid-1', dto, verified('GABC'))).rejects.toMatchObject({
         status: 410,
       });
       expect(gistRepository.update).not.toHaveBeenCalled();
     });
 
-    it('throws ForbiddenException when author does not match', async () => {
+    it('throws UnauthorizedException when the signature is absent', async () => {
+      // Spoofing scenario: the body author matches the stored author, but there
+      // is no verified signature, so the edit must be rejected.
+      const gist = mockGist({ created_at: new Date(), author: 'GABC' });
+      gistRepository.findByGistId.mockResolvedValue(gist);
+
+      await expect(service.update('uuid-1', { ...dto, author: 'GABC' }, null)).rejects.toThrow(
+        UnauthorizedException,
+      );
+      expect(gistRepository.update).not.toHaveBeenCalled();
+    });
+
+    it('throws ForbiddenException when the signed address does not match', async () => {
       const gist = mockGist({ created_at: new Date(), author: 'GOTHER' });
       gistRepository.findByGistId.mockResolvedValue(gist);
 
-      await expect(service.update('uuid-1', dto)).rejects.toThrow(ForbiddenException);
+      await expect(service.update('uuid-1', dto, verified('GABC'))).rejects.toThrow(
+        ForbiddenException,
+      );
       expect(gistRepository.update).not.toHaveBeenCalled();
     });
 
@@ -490,7 +513,9 @@ describe('GistsService', () => {
       const gist = mockGist({ created_at: new Date(), author: null });
       gistRepository.findByGistId.mockResolvedValue(gist);
 
-      await expect(service.update('uuid-1', dto)).rejects.toThrow(ForbiddenException);
+      await expect(service.update('uuid-1', dto, verified('GABC'))).rejects.toThrow(
+        ForbiddenException,
+      );
     });
 
     it('records lineage from the previous content_hash to a new cid', async () => {
@@ -501,7 +526,7 @@ describe('GistsService', () => {
       cacheService.del.mockResolvedValue();
       cacheService.delPattern.mockResolvedValue();
 
-      await service.update('uuid-1', dto);
+      await service.update('uuid-1', dto, verified('GABC'));
 
       expect(gistRepository.update).toHaveBeenCalledWith(
         'uuid-1',
@@ -521,7 +546,7 @@ describe('GistsService', () => {
       cacheService.del.mockResolvedValue();
       cacheService.delPattern.mockResolvedValue();
 
-      await service.update('uuid-1', dto);
+      await service.update('uuid-1', dto, verified('GABC'));
 
       expect(cacheService.del).toHaveBeenCalledWith('gist:one:uuid-1');
       expect(cacheService.delPattern).toHaveBeenCalled();
@@ -536,7 +561,7 @@ describe('GistsService', () => {
       cacheService.del.mockResolvedValue();
       cacheService.delPattern.mockResolvedValue();
 
-      const result = await service.update('uuid-1', dto);
+      const result = await service.update('uuid-1', dto, verified('GABC'));
 
       expect(result).toBe(updated);
     });

--- a/Backend/src/gists/gists.service.ts
+++ b/Backend/src/gists/gists.service.ts
@@ -5,6 +5,7 @@ import {
   Injectable,
   Logger,
   NotFoundException,
+  UnauthorizedException,
   UnprocessableEntityException,
 } from '@nestjs/common';
 import { CreateGistDto } from './dto/create-gist.dto';
@@ -61,7 +62,11 @@ export class GistsService {
     const content = stripHtml(dto.content);
 
     const locationCell = this.geoService.encode(dto.lat, dto.lon);
-    const author = stellarVerified ? stellarVerified.address : dto.author;
+
+    // Authorship comes only from a verified Stellar signature. An unsigned
+    // `dto.author` field is ignored so a client cannot attribute a gist to an
+    // arbitrary address.
+    const author = stellarVerified ? stellarVerified.address : null;
     const authorVerifiedAt = stellarVerified ? stellarVerified.verifiedAt : null;
 
     const requestHash = computeGistRequestHash({
@@ -235,7 +240,9 @@ export class GistsService {
     stellarVerified?: StellarVerified | null,
   ): Promise<Gist[]> {
     const createdAt = new Date().toISOString();
-    const author = stellarVerified ? stellarVerified.address : undefined;
+    // Authorship comes only from a verified Stellar signature; per-item
+    // `dto.author` fields are ignored.
+    const author = stellarVerified ? stellarVerified.address : null;
     const authorVerifiedAt = stellarVerified ? stellarVerified.verifiedAt : null;
 
     const prepared = dtos.map((dto) => {
@@ -246,7 +253,7 @@ export class GistsService {
         dto,
         content,
         locationCell,
-        effectiveAuthor: author ?? dto.author,
+        effectiveAuthor: author,
         payload: {
           content,
           lat: dto.lat,
@@ -348,7 +355,11 @@ export class GistsService {
     return result;
   }
 
-  async update(id: string, dto: UpdateGistDto): Promise<Gist> {
+  async update(
+    id: string,
+    dto: UpdateGistDto,
+    stellarVerified?: StellarVerified | null,
+  ): Promise<Gist> {
     const gist = await this.gistRepository.findByGistId(id);
 
     if (!gist) {
@@ -360,7 +371,13 @@ export class GistsService {
       throw new HttpException('Edit window has closed for this gist', HttpStatus.GONE);
     }
 
-    if (!gist.author || gist.author !== dto.author) {
+    // Authorship is derived from the verified Stellar signature, never the
+    // caller-supplied `dto.author` string (which is trivially spoofable).
+    const verifiedAddress = stellarVerified?.address ?? null;
+    if (!verifiedAddress) {
+      throw new UnauthorizedException('A valid Stellar signature is required to edit a gist');
+    }
+    if (!gist.author || gist.author !== verifiedAddress) {
       throw new ForbiddenException('Only the original author may edit this gist');
     }
 

--- a/Backend/test/gists.e2e.spec.ts
+++ b/Backend/test/gists.e2e.spec.ts
@@ -1,8 +1,38 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication, ValidationPipe } from '@nestjs/common';
 import * as request from 'supertest';
+import { Keypair } from '@stellar/stellar-sdk';
+import { createHash } from 'crypto';
 import { AppModule } from 'src/app.module';
 import { AllExceptionsFilter } from 'src/common/filters/all-exceptions.filter';
+
+// Mirrors StellarAuthGuard.canonicalizeBody so e2e requests can be signed
+// against the exact bytes the guard hashes.
+function canonicalizeBody(body: unknown): string {
+  if (body === null || body === undefined) return '';
+  if (typeof body !== 'object' || Array.isArray(body)) return JSON.stringify(body);
+  const keys = Object.keys(body as Record<string, unknown>).sort();
+  const canonical: Record<string, unknown> = {};
+  for (const key of keys) {
+    const value = (body as Record<string, unknown>)[key];
+    canonical[key] =
+      value !== null && typeof value === 'object' && !Array.isArray(value)
+        ? JSON.parse(canonicalizeBody(value))
+        : value;
+  }
+  return JSON.stringify(canonical);
+}
+
+function signHeaders(keypair: Keypair, body: unknown): Record<string, string> {
+  const timestamp = Math.floor(Date.now() / 1000);
+  const bodyHash = createHash('sha256').update(canonicalizeBody(body), 'utf-8').digest();
+  const message = `${timestamp}.${bodyHash.toString('hex')}`;
+  return {
+    'x-stellar-signature': keypair.sign(Buffer.from(message, 'utf-8')).toString('hex'),
+    'x-stellar-address': keypair.publicKey(),
+    'x-stellar-timestamp': String(timestamp),
+  };
+}
 
 describe('Gists (e2e)', () => {
   jest.setTimeout(30000);
@@ -162,35 +192,39 @@ describe('Gists (e2e)', () => {
   });
 
   describe('PATCH /gists/:id', () => {
-    async function createAuthoredGist(author = 'GABC...XYZ') {
+    async function createAuthoredGist(keypair = Keypair.random()) {
       const csrf = await getCsrfToken(app.getHttpServer());
+      const body = { content: 'original content', lat: 9.0579, lon: 7.4951 };
       const res = await request(app.getHttpServer())
         .post('/gists')
         .set('Cookie', csrf.cookie)
         .set('x-csrf-token', csrf.token)
-        .send({ content: 'original content', lat: 9.0579, lon: 7.4951, author })
+        .set(signHeaders(keypair, body))
+        .send(body)
         .expect(201);
-      return res.body;
+      return { gist: res.body, keypair };
     }
 
     it('should reject PATCH /gists/:id without CSRF token', async () => {
-      const gist = await createAuthoredGist();
+      const { gist } = await createAuthoredGist();
 
       await request(app.getHttpServer())
         .patch(`/gists/${gist.id}`)
-        .send({ content: 'fixed typo', author: 'GABC...XYZ' })
+        .send({ content: 'fixed typo' })
         .expect(403);
     });
 
     it('should edit a gist within the 60s window and preserve CID lineage', async () => {
-      const gist = await createAuthoredGist();
+      const { gist, keypair } = await createAuthoredGist();
       const csrf = await getCsrfToken(app.getHttpServer());
+      const patchBody = { content: 'fixed typo' };
 
       const res = await request(app.getHttpServer())
         .patch(`/gists/${gist.id}`)
         .set('Cookie', csrf.cookie)
         .set('x-csrf-token', csrf.token)
-        .send({ content: 'fixed typo', author: 'GABC...XYZ' })
+        .set(signHeaders(keypair, patchBody))
+        .send(patchBody)
         .expect(200);
 
       expect(res.body).toMatchObject({
@@ -202,38 +236,56 @@ describe('Gists (e2e)', () => {
       expect(res.body.content_hash).not.toBe(gist.content_hash);
     });
 
-    it('should return 403 when the author does not match', async () => {
-      const gist = await createAuthoredGist('GABC...XYZ');
+    it('should return 401 when PATCHing without Stellar signature headers', async () => {
+      const { gist } = await createAuthoredGist();
       const csrf = await getCsrfToken(app.getHttpServer());
 
       await request(app.getHttpServer())
         .patch(`/gists/${gist.id}`)
         .set('Cookie', csrf.cookie)
         .set('x-csrf-token', csrf.token)
-        .send({ content: 'imposter edit', author: 'GIMPOSTOR' })
+        .send({ content: 'fixed typo' })
+        .expect(401);
+    });
+
+    it('should return 403 when a different address signs the edit', async () => {
+      const { gist } = await createAuthoredGist();
+      const csrf = await getCsrfToken(app.getHttpServer());
+      const patchBody = { content: 'imposter edit' };
+
+      await request(app.getHttpServer())
+        .patch(`/gists/${gist.id}`)
+        .set('Cookie', csrf.cookie)
+        .set('x-csrf-token', csrf.token)
+        .set(signHeaders(Keypair.random(), patchBody))
+        .send(patchBody)
         .expect(403);
     });
 
     it('should return 404 for a non-existent gist', async () => {
       const csrf = await getCsrfToken(app.getHttpServer());
+      const patchBody = { content: 'no such gist' };
 
       await request(app.getHttpServer())
         .patch('/gists/00000000-0000-0000-0000-000000000000')
         .set('Cookie', csrf.cookie)
         .set('x-csrf-token', csrf.token)
-        .send({ content: 'no such gist', author: 'GABC...XYZ' })
+        .set(signHeaders(Keypair.random(), patchBody))
+        .send(patchBody)
         .expect(404);
     });
 
     it('should return 400 when content exceeds 280 characters', async () => {
-      const gist = await createAuthoredGist();
+      const { gist, keypair } = await createAuthoredGist();
       const csrf = await getCsrfToken(app.getHttpServer());
+      const patchBody = { content: 'x'.repeat(281) };
 
       await request(app.getHttpServer())
         .patch(`/gists/${gist.id}`)
         .set('Cookie', csrf.cookie)
         .set('x-csrf-token', csrf.token)
-        .send({ content: 'x'.repeat(281), author: 'GABC...XYZ' })
+        .set(signHeaders(keypair, patchBody))
+        .send(patchBody)
         .expect(400);
     });
   });


### PR DESCRIPTION
## Summary

Closes #424

The gist API trusted caller-supplied strings for authorship: `POST /gists` fell back to the body `author` field whenever the optional `StellarAuthGuard` produced no verified identity, and `PATCH /gists/:id` authorized edits by string-equality against a body-supplied `author`. This PR makes authorship a function of the verified Stellar signature only: anonymous posts store `author = null`, and edits require a valid `X-Stellar-*` signature whose address matches the stored author.

## Why

`StellarAuthGuard` is optional-by-design so anonymous posting keeps working, but `GistsService.create` then trusted `dto.author` (`@IsString()` with no format check), letting any client attribute a gist to any address. The edit path was worse: `PATCH /gists/:id` was the only mutation with no guard, and `update()` compared `gist.author !== dto.author` against a caller-supplied body field — so anyone could edit any gist inside the 60-second `EDIT_WINDOW_MS` by posting the victim's address string.

The fix reuses the existing `StellarAuthGuard` / `StellarVerifiedUser` machinery rather than introducing a new token scheme (explicitly out of scope). The one subtlety is preserving anonymous posting while closing impersonation: an absent signature now maps to `author = null` instead of a body fallback, and the verified address is threaded through the controller into `update()`.

## What was built

`Backend/src/gists/`:

| File | What it contains |
|---|---|
| `gists.service.ts` | `create()`/`createBatch()` derive `author` solely from `stellarVerified?.address` (else `null`), ignoring `dto.author`. `update()` takes `stellarVerified`, throws `401 UnauthorizedException` when no verified signature is present, and compares the verified address (never `dto.author`) to the stored `author`. Matched by `gists.service.spec.ts`. |
| `gists.controller.ts` | `update()` now runs behind `@UseGuards(StellarAuthGuard)` and passes `@StellarVerifiedUser()` to the service. Swagger `@ApiHeader` docs for the three `X-Stellar-*` headers plus 401/403 `@ApiResponse`. Matched by `gists.controller.spec.ts`. |
| `dto/update-gist.dto.ts` | `author` is now `@IsOptional()` and documented as deprecated/ignored, so existing clients still validate while authorship is derived from the signature. |

## Integration changes outside `Backend/src/gists/`

- **`Backend/test/gists.e2e.spec.ts`** — added a `signHeaders` helper that canonicalizes the body exactly as `StellarAuthGuard` does and signs with `Keypair`; the authored-gist fixture now posts with real signature headers, and new tests assert `401` without headers and `403` for a different signing address.
- **`Backend/README.md`** — documents that posting is anonymous-by-default (an unsigned `author` is ignored) and that editing requires `X-Stellar-Address` / `X-Stellar-Signature` / `X-Stellar-Timestamp`, returning `401` without them.

## Acceptance criteria coverage

### Contract
- [x] `PATCH /gists/:id` returns `401` when the Stellar signature headers are absent, and succeeds only when the verified address equals the stored `author`. (`@UseGuards(StellarAuthGuard)` + `update()` throwing `UnauthorizedException` when `stellarVerified` is null; `test/gists.e2e.spec.ts` — "should return 401 when PATCHing without Stellar signature headers" and "should return 403 when a different address signs the edit")
- [x] `POST /gists` and `POST /gists/batch` ignore an unsigned `author` field; a gist's `author` is set only from a verified signature. (`create()`/`createBatch()` derive `author` from `stellarVerified?.address ?? null`; `gists.service.spec.ts` — "ignores an unsigned author body field and posts anonymously" plus the batch test asserting both items post with `null`)

### Service
- [x] A gist posted anonymously has `author = null` and cannot be edited (unchanged behavior for true anonymous posts). (`create()` sets `author: null`; `update()` rejects when `gist.author` is null — `gists.service.spec.ts` — "throws ForbiddenException when the gist has no author")

### Tests
- [x] A unit test asserts `GistsService.update` rejects a request whose body `author` matches the stored author but whose signature is absent or invalid. (`gists.service.spec.ts` — "throws UnauthorizedException when the signature is absent", passing `{ ...dto, author: 'GABC' }` with a `null` verified user)
- [x] An e2e test PATCHes with valid Stellar headers and succeeds, and fails `401` without them. (`test/gists.e2e.spec.ts` — "should edit a gist within the 60s window and preserve CID lineage" (signed) and "should return 401 when PATCHing without Stellar signature headers")

### Documentation
- [x] `Backend/README.md` and the Swagger docs describe the required signature headers for editing. (`Backend/README.md` PATCH section; `gists.controller.ts` `@ApiHeader` declarations)

## Test plan

- [x] `CI=true npm test -- --runInBand` — 181 passed, 13 skipped (1 new unit test; the skips are the pre-existing Postgres+PostGIS integration suites)
- [x] `npx tsc --noEmit -p tsconfig.json` — 0 errors
- [x] `npx eslint <changed files>` — 0 errors / 0 warnings
- [x] `npm run build` — succeeds
- [ ] Manual: `npm run test:e2e` requires a local Postgres+PostGIS and was not run here; the e2e signing helper was instead verified against the guard's canonicalization directly.

## Env vars / Notes

No new environment variables or config keys. The `PATCH /gists/:id` contract change is breaking for unsigned callers (now `401`), but no sibling repository consumes it (per the issue). The `author` body field on `PATCH` is deprecated but still accepted-and-ignored, so existing clients that send it do not fail validation.