### PR TITLE
fix(frontend): obtain CSRF token and send credentialed POST for gists

### DIFF
--- a/Frontend/src/api/gists.test.ts
+++ b/Frontend/src/api/gists.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { postGist, GistApiError, GistPayload, GistResponse } from './gists';
+import type { GistPayload, GistResponse } from './gists';
 
 const mockFetch = vi.fn();
-globalThis.fetch = mockFetch;
+
+let postGist: typeof import('./gists').postGist;
+let GistApiError: typeof import('./gists').GistApiError;
 
 const validPayload: GistPayload = {
   content: 'Test gist',
@@ -19,84 +21,142 @@ const mockResponse: GistResponse = {
   created_at: '2026-07-28T12:00:00Z',
 };
 
-describe('postGist', () => {
-  beforeEach(() => {
-    mockFetch.mockReset();
-  });
+const csrfOk = (token: string) => ({
+  ok: true,
+  json: () => Promise.resolve({ csrfToken: token }),
+});
 
-  it('should POST to the correct endpoint with JSON content-type', async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve(mockResponse),
-    });
+const postOk = () => ({
+  ok: true,
+  json: () => Promise.resolve(mockResponse),
+});
+
+// The module memoizes the CSRF token at module scope, so reset the module
+// registry before each test to get a clean cache.
+beforeEach(async () => {
+  vi.resetModules();
+  mockFetch.mockReset();
+  globalThis.fetch = mockFetch;
+
+  const mod = await import('./gists');
+  postGist = mod.postGist;
+  GistApiError = mod.GistApiError;
+});
+
+describe('postGist', () => {
+  it('should POST to /gists with credentials, CSRF token, and JSON content-type', async () => {
+    mockFetch
+      .mockResolvedValueOnce(csrfOk('token-1'))
+      .mockResolvedValueOnce(postOk());
 
     await postGist(validPayload);
 
-    const [url, options] = mockFetch.mock.calls[0];
-    expect(url).toContain('/gists');
+    // First call: GET /csrf-token with credentialed fetch.
+    const [csrfUrl, csrfOptions] = mockFetch.mock.calls[0];
+    expect(csrfUrl).toBe('http://localhost:3000/csrf-token');
+    expect(csrfOptions.method).toBe('GET');
+    expect(csrfOptions.credentials).toBe('include');
+
+    // Second call: POST /gists with the token and credentials.
+    const [url, options] = mockFetch.mock.calls[1];
+    expect(url).toBe('http://localhost:3000/gists');
     expect(options.method).toBe('POST');
+    expect(options.credentials).toBe('include');
     expect(options.headers['Content-Type']).toBe('application/json');
+    expect(options.headers['x-csrf-token']).toBe('token-1');
   });
 
   it('should send an Idempotency-Key header on every post', async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve(mockResponse),
-    });
+    mockFetch
+      .mockResolvedValueOnce(csrfOk('token-1'))
+      .mockResolvedValueOnce(postOk());
 
     await postGist(validPayload);
 
-    const [, options] = mockFetch.mock.calls[0];
+    const [, options] = mockFetch.mock.calls[1];
     expect(typeof options.headers['Idempotency-Key']).toBe('string');
     expect(options.headers['Idempotency-Key'].length).toBeGreaterThan(0);
   });
 
   it('should reuse a caller-supplied idempotency key', async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve(mockResponse),
-    });
+    mockFetch
+      .mockResolvedValueOnce(csrfOk('token-1'))
+      .mockResolvedValueOnce(postOk());
 
     await postGist(validPayload, { idempotencyKey: 'key-123' });
 
-    const [, options] = mockFetch.mock.calls[0];
+    const [, options] = mockFetch.mock.calls[1];
     expect(options.headers['Idempotency-Key']).toBe('key-123');
   });
 
   it('should return the server-confirmed gist on success', async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve(mockResponse),
-    });
+    mockFetch
+      .mockResolvedValueOnce(csrfOk('token-1'))
+      .mockResolvedValueOnce(postOk());
 
     const result = await postGist(validPayload);
     expect(result).toEqual(mockResponse);
   });
 
-  it('should include author in the payload when provided', async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve(mockResponse),
-    });
+  it('should fetch the CSRF token once and reuse it across posts', async () => {
+    mockFetch
+      .mockResolvedValueOnce(csrfOk('token-1'))
+      .mockResolvedValueOnce(postOk())
+      .mockResolvedValueOnce(postOk());
 
-    const payloadWithAuthor: GistPayload = {
-      ...validPayload,
-      author: 'anonymous-raccoon',
-    };
+    await postGist(validPayload);
+    await postGist(validPayload);
 
-    await postGist(payloadWithAuthor);
+    const csrfCalls = mockFetch.mock.calls.filter(([url]) =>
+      String(url).includes('/csrf-token'),
+    );
+    expect(csrfCalls).toHaveLength(1);
 
-    const [, options] = mockFetch.mock.calls[0];
-    const body = JSON.parse(options.body);
-    expect(body.author).toBe('anonymous-raccoon');
+    const [, firstOptions] = mockFetch.mock.calls[1];
+    const [, secondOptions] = mockFetch.mock.calls[2];
+    expect(firstOptions.headers['x-csrf-token']).toBe('token-1');
+    expect(secondOptions.headers['x-csrf-token']).toBe('token-1');
   });
 
-  it('should throw GistApiError with status when response is not ok', async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: false,
-      status: 422,
-      text: () => Promise.resolve('Validation failed'),
-    });
+  it('should refetch once and retry when a stale-token 403 is returned', async () => {
+    mockFetch
+      .mockResolvedValueOnce(csrfOk('stale-token'))
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+        text: () => Promise.resolve('Invalid or missing CSRF token'),
+      })
+      .mockResolvedValueOnce(csrfOk('fresh-token'))
+      .mockResolvedValueOnce(postOk());
+
+    const result = await postGist(validPayload);
+    expect(result).toEqual(mockResponse);
+
+    // Two /csrf-token fetches: the initial one plus one after the 403.
+    const csrfCalls = mockFetch.mock.calls.filter(([url]) =>
+      String(url).includes('/csrf-token'),
+    );
+    expect(csrfCalls).toHaveLength(2);
+
+    // The retry POST carries the freshly fetched token.
+    const [, retryOptions] = mockFetch.mock.calls[3];
+    expect(retryOptions.headers['x-csrf-token']).toBe('fresh-token');
+  });
+
+  it('should throw GistApiError when a 403 persists after refetch and retry', async () => {
+    mockFetch
+      .mockResolvedValueOnce(csrfOk('stale-token'))
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+        text: () => Promise.resolve('Invalid or missing CSRF token'),
+      })
+      .mockResolvedValueOnce(csrfOk('fresh-token'))
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+        text: () => Promise.resolve('Invalid or missing CSRF token'),
+      });
 
     let caught: unknown;
     try {
@@ -106,17 +166,60 @@ describe('postGist', () => {
     }
 
     expect(caught).toBeInstanceOf(GistApiError);
-    expect((caught as GistApiError).status).toBe(422);
-    expect((caught as GistApiError).name).toBe('GistApiError');
-    expect((caught as GistApiError).message).toContain('POST /gists failed (422)');
+    expect((caught as InstanceType<typeof GistApiError>).status).toBe(403);
+  });
+
+  it('should include author in the payload when provided', async () => {
+    mockFetch
+      .mockResolvedValueOnce(csrfOk('token-1'))
+      .mockResolvedValueOnce(postOk());
+
+    const payloadWithAuthor: GistPayload = {
+      ...validPayload,
+      author: 'anonymous-raccoon',
+    };
+
+    await postGist(payloadWithAuthor);
+
+    const [, options] = mockFetch.mock.calls[1];
+    const body = JSON.parse(options.body);
+    expect(body.author).toBe('anonymous-raccoon');
+  });
+
+  it('should throw GistApiError with status when response is not ok', async () => {
+    mockFetch
+      .mockResolvedValueOnce(csrfOk('token-1'))
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 422,
+        text: () => Promise.resolve('Validation failed'),
+      });
+
+    let caught: unknown;
+    try {
+      await postGist(validPayload);
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(GistApiError);
+    expect((caught as InstanceType<typeof GistApiError>).status).toBe(422);
+    expect((caught as InstanceType<typeof GistApiError>).name).toBe(
+      'GistApiError',
+    );
+    expect((caught as InstanceType<typeof GistApiError>).message).toContain(
+      'POST /gists failed (422)',
+    );
   });
 
   it('should handle errors where text() fails', async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: false,
-      status: 500,
-      text: () => Promise.reject(new Error('Body stream already read')),
-    });
+    mockFetch
+      .mockResolvedValueOnce(csrfOk('token-1'))
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        text: () => Promise.reject(new Error('Body stream already read')),
+      });
 
     await expect(postGist(validPayload)).rejects.toThrow(
       'POST /gists failed (500): Unable to read response body',
@@ -124,20 +227,21 @@ describe('postGist', () => {
   });
 
   it('should throw on network failure', async () => {
-    mockFetch.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+    mockFetch
+      .mockResolvedValueOnce(csrfOk('token-1'))
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'));
 
     await expect(postGist(validPayload)).rejects.toThrow('Failed to fetch');
   });
 
   it('should serialize the payload as JSON', async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve(mockResponse),
-    });
+    mockFetch
+      .mockResolvedValueOnce(csrfOk('token-1'))
+      .mockResolvedValueOnce(postOk());
 
     await postGist(validPayload);
 
-    const [, options] = mockFetch.mock.calls[0];
+    const [, options] = mockFetch.mock.calls[1];
     const body = JSON.parse(options.body);
     expect(body.content).toBe('Test gist');
     expect(body.lat).toBe(6.5244);
@@ -145,14 +249,13 @@ describe('postGist', () => {
   });
 
   it('should default to localhost:3000 when NEXT_PUBLIC_API_URL is not set', async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve(mockResponse),
-    });
+    mockFetch
+      .mockResolvedValueOnce(csrfOk('token-1'))
+      .mockResolvedValueOnce(postOk());
 
     await postGist(validPayload);
 
-    const [url] = mockFetch.mock.calls[0];
+    const [url] = mockFetch.mock.calls[1];
     expect(url).toBe('http://localhost:3000/gists');
   });
 });

--- a/Frontend/src/api/gists.ts
+++ b/Frontend/src/api/gists.ts
@@ -51,6 +51,76 @@ function generateIdempotencyKey(): string {
 }
 
 /**
+ * Memoized in-flight promise for the CSRF token. The backend uses a
+ * double-submit cookie: `GET /csrf-token` sets the httpOnly `csrfToken`
+ * cookie (the secret) and returns the token to echo back in the
+ * `x-csrf-token` header. We fetch once and reuse the token, sharing the
+ * in-flight promise so concurrent posts trigger a single fetch.
+ */
+let csrfTokenPromise: Promise<string> | null = null;
+
+/**
+ * Fetch a fresh CSRF token from `/csrf-token`. `credentials: 'include'` is
+ * required so the httpOnly secret cookie is set and later replayed.
+ */
+async function fetchCsrfToken(): Promise<string> {
+  const res = await fetch(`${BASE_URL}/csrf-token`, {
+    method: "GET",
+    credentials: "include",
+  });
+
+  if (!res.ok) {
+    let body: string;
+    try {
+      body = await res.text();
+    } catch {
+      body = "Unable to read response body";
+    }
+    throw new GistApiError(
+      `GET /csrf-token failed (${res.status}): ${body}`,
+      res.status,
+    );
+  }
+
+  const json = (await res.json()) as { csrfToken?: string };
+  if (!json.csrfToken) {
+    throw new GistApiError("GET /csrf-token returned no token");
+  }
+  return json.csrfToken;
+}
+
+/** Return the memoized CSRF token, fetching it on first use. */
+function ensureCsrfToken(): Promise<string> {
+  if (!csrfTokenPromise) {
+    csrfTokenPromise = fetchCsrfToken();
+  }
+  return csrfTokenPromise;
+}
+
+/** Drop the memoized token so the next call fetches a fresh one. */
+function invalidateCsrfToken(): void {
+  csrfTokenPromise = null;
+}
+
+/** POST the payload with the CSRF token, idempotency key, and credentialed fetch. */
+async function postGistRequest(
+  payload: GistPayload,
+  token: string,
+  idempotencyKey: string,
+): Promise<Response> {
+  return fetch(`${BASE_URL}/gists`, {
+    method: "POST",
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+      "x-csrf-token": token,
+      "Idempotency-Key": idempotencyKey,
+    },
+    body: JSON.stringify(payload),
+  });
+}
+
+/**
  * POST a new gist to the backend.
  *
  * Returns the server-confirmed gist on success.
@@ -60,17 +130,18 @@ export async function postGist(
   payload: GistPayload,
   options: PostGistOptions = {},
 ): Promise<GistResponse> {
-  const url = `${BASE_URL}/gists`;
   const idempotencyKey = options.idempotencyKey ?? generateIdempotencyKey();
 
-  const res = await fetch(url, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "Idempotency-Key": idempotencyKey,
-    },
-    body: JSON.stringify(payload),
-  });
+  let token = await ensureCsrfToken();
+  let res = await postGistRequest(payload, token, idempotencyKey);
+
+  // The backend may rotate the double-submit cookie; a 403 can mean the cached
+  // token is stale. Refetch once and retry before surfacing the error.
+  if (res.status === 403) {
+    invalidateCsrfToken();
+    token = await ensureCsrfToken();
+    res = await postGistRequest(payload, token, idempotencyKey);
+  }
 
   if (!res.ok) {
     let body: string;


### PR DESCRIPTION
## Summary

Closes #425

`postGist` issued `POST /gists` with only a `Content-Type` header, so the backend's double-submit CSRF middleware rejected every pin with `403` and the optimistic gist was always rolled back. This PR makes the client satisfy the existing middleware: it fetches the CSRF token from `/csrf-token` once (memoized, with a shared in-flight promise), sends it in `x-csrf-token` with `credentials: 'include'`, and refetches once plus retries when a `403` signals token rotation.

## Why

The backend uses the double-submit cookie pattern (`Backend/src/common/middleware/csrf.middleware.ts`): the client must first `GET /csrf-token` (which sets the httpOnly `csrfToken` cookie and returns the token), then echo the token in `x-csrf-token` while replaying the cookie via `credentials: 'include'`. `postGist` did neither, and there was no `csrf` handling anywhere else in `Frontend/`. Because `NEXT_PUBLIC_API_URL` is cross-origin, simply adding a header is not enough — the httpOnly cookie must also be sent, which only happens with credentialed fetch.

Token acquisition is memoized rather than fetched before every post: the issue calls out that a naive per-post fetch adds a round trip and races when several gists are pinned in quick succession. Sharing the in-flight promise means concurrent posts collapse to a single fetch, and the token is only refetched after a `403` that indicates rotation.

## What was built

`Frontend/src/api/gists.ts`:

| Symbol | What it contains |
|---|---|
| `csrfTokenPromise` / `fetchCsrfToken()` | Module-scoped memoized in-flight promise that `GET`s `/csrf-token` with `credentials: 'include'` and extracts `csrfToken`. |
| `ensureCsrfToken()` | Returns the cached token, fetching on first use only. |
| `invalidateCsrfToken()` | Clears the cache so the next call refetches (used after a rotation `403`). |
| `postGistRequest()` | The single POST path: `credentials: 'include'`, `Content-Type`, and `x-csrf-token`. |
| `postGist()` | Fetches the token, POSTs, and on a `403` invalidates, refetches once, and retries before surfacing the error. Public signature unchanged. |

Matched by `Frontend/src/api/gists.test.ts` (rewritten around `vi.resetModules()` so the module-scoped token cache starts clean each test).

## Integration changes outside `Frontend/src/api/gists.ts`

- **`Frontend/src/api/gists.test.ts`** — updated existing assertions to mock the `/csrf-token` GET, and added three tests: credentials/token on the POST, token reuse across posts, and the stale-token `403` refetch-and-retry path (plus a persistent-`403` guard).

No backend files were modified; the backend API contract is unchanged — the client now conforms to it. No other frontend callers change because `postGist`'s signature is unchanged.

## Acceptance criteria coverage

### Contract
- [x] `postGist` sends `credentials: 'include'` and a valid `x-csrf-token` header on every request. (`postGistRequest()` sets both; `gists.test.ts` — "should POST to /gists with credentials, CSRF token, and JSON content-type")
- [x] The CSRF token is fetched from `/csrf-token` once and reused; a `403` due to token rotation triggers one refetch and retry. (`ensureCsrfToken()` memoization + `postGist()` 403 branch; `gists.test.ts` — "should fetch the CSRF token once and reuse it across posts" and "should refetch once and retry when a stale-token 403 is returned")

### Tests
- [x] `Frontend/src/api/gists.test.ts` asserts the CSRF token and `credentials` are included in the outgoing `fetch` call. ("should POST to /gists with credentials, CSRF token, and JSON content-type")
- [x] A test simulates a stale-token `403` and asserts the retry succeeds. ("should refetch once and retry when a stale-token 403 is returned")

## Test plan

- [x] `npm run test` — 83 passed (3 new tests for this feature)
- [x] `npx tsc --noEmit -p tsconfig.json` — no new type errors versus base (one pre-existing `TS2578` in `src/components/landing/Features.test.tsx:103` exists on `main` and is untouched)
- [x] `npm run lint` — exit 0 (one pre-existing unrelated `<img>` warning in `Features.test.tsx`)
- [x] `npm run build` — succeeds
- [ ] Manual: a reviewer running the app against a CSRF-enabled backend should see a gist pin succeed (no 403 toast).

## Env vars / Notes

No new environment variables or config keys. The backend CORS config already sets `credentials: true` with the frontend origins, so credentialed cross-origin fetch works without backend changes. The module-scoped token cache is intentional; the test suite resets it via `vi.resetModules()` in `beforeEach`.