### PR TITLE
fix(gist-registry): require author auth for non-anonymous gists

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -50,7 +50,7 @@ Location-aware gist registry for storing and retrieving gists by geographic cell
 | `created_at` | `u64` | Ledger timestamp at creation |
 
 **Methods:**
-- `post_gist(author, location_cell, content_hash)` - Register a new gist
+- `post_gist(author, location_cell, content_hash)` - Register a new gist. Anonymous posting (`author = None`) requires no auth; a non-anonymous post (`Some(address)`) requires that address to authorize the invocation (`require_auth`), so gist attribution cannot be forged.
 - `get_gist(gist_id)` - Retrieve a gist record by id
 - `list_gists_by_cell(location_cell, cursor, limit)` - Paginated list of gists within a location cell
 

--- a/contracts/gist-registry/src/lib.rs
+++ b/contracts/gist-registry/src/lib.rs
@@ -31,12 +31,22 @@ pub struct GistRegistry;
 #[contractimpl]
 impl GistRegistry {
     /// Register a new gist on-chain. Returns the assigned gist_id.
+    ///
+    /// When `author` is `Some(address)`, that address must authorize the
+    /// invocation (`address.require_auth()`), so attribution cannot be forged
+    /// by a caller who merely passes someone else's address. `None` remains
+    /// fully anonymous and requires no auth.
     pub fn post_gist(
         env: Env,
         author: Option<Address>,
         location_cell: String,
         content_hash: String,
     ) -> u64 {
+        // A non-anonymous post must be authorized by the attributed author.
+        if let Some(a) = &author {
+            a.require_auth();
+        }
+
         let gist_id: u64 = env.storage().instance().get(&GIST_COUNT).unwrap_or(0) + 1;
 
         let gist = Gist {
@@ -95,8 +105,8 @@ impl GistRegistry {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use soroban_sdk::testutils::Ledger;
-    use soroban_sdk::{Env, String};
+    use soroban_sdk::testutils::{Address as _, Ledger};
+    use soroban_sdk::{Address, Env, String};
 
     #[test]
     fn test_post_and_get_gist() {
@@ -117,6 +127,43 @@ mod tests {
         assert_eq!(gist.location_cell, location);
         assert_eq!(gist.content_hash, hash);
         assert_eq!(gist.created_at, 1_000_000);
+    }
+
+    #[test]
+    fn test_post_gist_with_signed_author() {
+        let env = Env::default();
+        let contract_id = env.register(GistRegistry, ());
+        let client = GistRegistryClient::new(&env, &contract_id);
+
+        let author = Address::generate(&env);
+        env.mock_all_auths();
+
+        let location = String::from_str(&env, "r3gx");
+        let hash = String::from_str(&env, "QmTest123");
+
+        let id = client.post_gist(&Some(author.clone()), &location, &hash);
+        assert_eq!(id, 1);
+
+        let gist = client.get_gist(&id).expect("gist should exist");
+        assert_eq!(gist.author, Some(author));
+    }
+
+    #[test]
+    // `author.require_auth()` fails when the attributed author has not signed
+    // the invocation; the host surfaces this as `Error(Auth, InvalidAction)`.
+    #[should_panic(expected = "Error(Auth, InvalidAction)")]
+    fn test_post_gist_with_unauthenticated_author_fails() {
+        let env = Env::default();
+        let contract_id = env.register(GistRegistry, ());
+        let client = GistRegistryClient::new(&env, &contract_id);
+
+        let victim = Address::generate(&env);
+        // No auth is mocked, so the caller cannot authorize on the victim's behalf.
+
+        let location = String::from_str(&env, "r3gx");
+        let hash = String::from_str(&env, "QmTest123");
+
+        client.post_gist(&Some(victim), &location, &hash);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #426

`GistRegistry::post_gist` accepted an `author: Option<Address>` and stored it verbatim with no `require_auth()`, so any account could post a gist attributed to any other Stellar address — and the forged author propagated into `GET /gists` via the indexer. This PR branches on the author: `None` stays anonymous (no auth), while `Some(address)` now calls `address.require_auth()` so only the attributed account can authorize its own gist.

## Why

The contract had the identity machinery available (`require_auth`) but never invoked it for attribution. Anonymous posting is a documented feature and must keep working, so the fix cannot simply require auth unconditionally. The correct move is a branch: a `Some(address)` post is authorized by that address, and a `None` post requires nothing. This mirrors the repo's established pattern in `contracts/governance/src/lib.rs` (`proposer.require_auth()` / `caller.require_auth()`).

This is an ABI-semantics change: a `Some(author)` post now fails unless that author signed. The only backend call site, `Backend/src/soroban/soroban.service.ts`, is mock-only (it throws "Real Soroban integration not yet implemented" outside mock mode), so no live integration breaks today; when the real RPC integration is built it must supply the author's signing key material.

## What was built

`contracts/gist-registry/src/lib.rs`:

| Change | What it contains |
|---|---|
| `post_gist` | Adds `if let Some(a) = &author { a.require_auth(); }` before the gist is persisted, plus a doc comment stating the auth rule. |
| `tests::test_post_gist_with_signed_author` | Generates an author, mocks auth, posts `Some(author)`, and asserts the stored `Gist.author` equals the signed address. |
| `tests::test_post_gist_with_unauthenticated_author_fails` | Posts `Some(victim)` with no mocked auth and asserts the call panics (`Error(Auth, InvalidAction)`). |

## Integration changes outside `contracts/gist-registry/src/lib.rs`

- **`contracts/README.md`** — the `post_gist` method entry now documents that `None` is anonymous and `Some(address)` requires the address to sign (`require_auth`).

No backend or frontend files were modified. `Backend/src/soroban/soroban.service.ts` (mock-only) and the existing `None`-based call sites are unaffected by this change.

## Acceptance criteria coverage

### Contract
- [x] `post_gist` with `Some(author)` requires that author's auth and fails otherwise. (`a.require_auth()` in `post_gist`; `tests::test_post_gist_with_unauthenticated_author_fails` — panics `Error(Auth, InvalidAction)`)
- [x] `post_gist` with `None` remains anonymous and does not require auth. (auth is only invoked inside the `Some` branch; `tests::test_post_and_get_gist` and `tests::test_list_gists_by_cell` still pass with `None` and no mocked auth)

### Tests
- [x] A test posts with `Some(author)` using a signed author and asserts the stored `Gist.author` matches. (`tests::test_post_gist_with_signed_author`)
- [x] A test posts `Some(victim)` from a different caller and asserts the call fails. (`tests::test_post_gist_with_unauthenticated_author_fails`)

### Documentation
- [x] `contracts/README.md` documents that non-anonymous gists require the author to sign. (updated `post_gist` method description)

## Test plan

- [x] `cargo fmt --all -- --check` — passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — 0 warnings
- [x] `cargo check --workspace --all-targets` — succeeds
- [x] `cargo test --workspace` — 34 passed (2 new tests in `gist-registry`)
- [x] `cargo build --workspace --target wasm32-unknown-unknown --release` — succeeds
- [ ] Manual: none; the ABI semantics are covered by the contract tests above.

## Env vars / Notes

No new environment variables or config keys. This is a contract ABI-semantics change (a `Some(author)` post now requires that author's signature), so any future non-mock Soroban integration must sign as the author — the current `SorobanService.postGist` is mock-only and unaffected. A redeploy of `GistRegistry` plus regenerated bindings is required before release, as the issue notes.