### PR TITLE
fix(gists): invalidate nearby cache with raw coordinates

### DIFF
--- a/Backend/src/gists/gists.service.spec.ts
+++ b/Backend/src/gists/gists.service.spec.ts
@@ -245,6 +245,40 @@ describe('GistsService', () => {
     });
   });
 
+  describe('nearby cache invalidation', () => {
+    it('invalidates with the same full-precision coordinates findNearby caches with', async () => {
+      const lat = 9.0579123;
+      const lon = 7.4951567;
+      const paginatedResult = {
+        data: [mockGist()],
+        pagination: { count: 1, cursor: null, hasMore: false },
+      };
+
+      // Capture the cache key findNearby would write for a query at this coordinate.
+      cacheService.get.mockResolvedValue(null);
+      cacheService.set.mockResolvedValue();
+      gistRepository.findNearby.mockResolvedValue(paginatedResult);
+      await service.findNearby({ lat, lon, radius: 500, limit: 20 });
+      const cacheKey = cacheService.set.mock.calls[0][0] as string;
+
+      // Post a gist at the same coordinate and capture the invalidation pattern.
+      geoService.encode.mockReturnValue('s1t7d8c');
+      ipfsService.pinJson.mockResolvedValue({ cid: 'mock_Qmabc', mock: true });
+      sorobanService.postGist.mockResolvedValue({ gistId: '1', txHash: 'tx1', mock: true });
+      gistRepository.create.mockResolvedValue(mockGist());
+      cacheService.delPattern.mockResolvedValue();
+
+      await service.create({ content: 'Test', lat, lon });
+
+      const pattern = cacheService.delPattern.mock.calls[0][0] as string;
+
+      // The pattern uses the raw (unrounded) coordinates and its `*` suffix
+      // matches the key findNearby actually wrote.
+      expect(pattern).toBe(`gist:nearby:${lat}:${lon}:*`);
+      expect(cacheKey.startsWith(pattern.slice(0, -1))).toBe(true);
+    });
+  });
+
   describe('findOne()', () => {
     it('returns cached gist on cache hit', async () => {
       const gist = mockGist();

--- a/Backend/src/gists/gists.service.ts
+++ b/Backend/src/gists/gists.service.ts
@@ -21,6 +21,21 @@ import { StellarVerified } from '../auth/interfaces/stellar-verified.interface';
 
 const EDIT_WINDOW_MS = 60_000;
 
+/**
+ * Shared prefix for nearby-cache keys. Both the cache key written by
+ * `findNearby` and the invalidation pattern used by `invalidateNearbyCache`
+ * must derive from the same coordinate serialization; otherwise a rounded
+ * pattern misses the full-precision keys the query actually writes.
+ */
+function nearbyCachePrefix(lat: number, lon: number): string {
+  return `gist:nearby:${lat}:${lon}`;
+}
+
+/** Full cache key for an uncursor'd nearby query. */
+function nearbyCacheKey(lat: number, lon: number, radius?: number, limit?: number): string {
+  return `${nearbyCachePrefix(lat, lon)}:${radius || 500}:${limit || 20}`;
+}
+
 @Injectable()
 export class GistsService {
   private readonly logger = new Logger(GistsService.name);
@@ -142,7 +157,7 @@ export class GistsService {
       });
     }
 
-    const cacheKey = `gist:nearby:${query.lat}:${query.lon}:${query.radius || 500}:${query.limit || 20}`;
+    const cacheKey = nearbyCacheKey(query.lat, query.lon, query.radius, query.limit);
     const cached = await this.cacheService.get<PaginatedResponse<Gist>>(cacheKey);
 
     if (cached) {
@@ -227,9 +242,9 @@ export class GistsService {
   }
 
   private async invalidateNearbyCache(lat: number, lon: number): Promise<void> {
-    // Invalidate all nearby cache keys for this area
-    // We use a pattern to match all nearby queries
-    const pattern = `gist:nearby:${lat.toFixed(4)}:${lon.toFixed(4)}:*`;
+    // Invalidate every radius/limit variant for this coordinate, using the
+    // same coordinate serialization findNearby uses for its cache keys.
+    const pattern = `${nearbyCachePrefix(lat, lon)}:*`;
     await this.cacheService.delPattern(pattern);
     this.logger.debug(`Invalidated nearby cache pattern: ${pattern}`);
   }


### PR DESCRIPTION
## Summary

Closes #428

`findNearby` built its cache key from full-precision `lat`/`lon`, but `invalidateNearbyCache` rounded the same coordinates to 4 decimals before building the `delPattern` glob, so the pattern almost never matched the keys the query actually wrote. A posted or edited gist therefore left nearby results stale for the 60-second TTL. This PR makes both paths derive from a single shared prefix helper, so the key and the invalidation pattern use identical coordinate serialization.

## Why

The two code paths encoded the same concept (`gist:nearby:<lat>:<lon>`) in two different ways: the key interpolated raw numbers (`${query.lat}`) while the pattern interpolated `lat.toFixed(4)`. A gist at `lat = 9.0579123` produced the pattern `gist:nearby:9.0579:7.4952:*`, which Redis `KEYS` cannot match against the written key `gist:nearby:9.0579123:7.4951567:500:20`. The fix is not to pick a rounding on one side but to eliminate the divergence: a single `nearbyCachePrefix` helper is the only place that serializes coordinates, and both the key and the pattern consume it.

The default `radius`/`limit` (`|| 500` / `|| 20`) behavior is preserved exactly; only the coordinate serialization is unified.

## What was built

`Backend/src/gists/gists.service.ts`:

| Symbol | What it contains |
|---|---|
| `nearbyCachePrefix(lat, lon)` | The single source of truth for `gist:nearby:<lat>:<lon>`, used by both the cache key and the invalidation pattern. |
| `nearbyCacheKey(lat, lon, radius?, limit?)` | The full cache key for an uncursor'd nearby query, built from the shared prefix plus the radius/limit defaults. |
| `findNearby` | Now builds its key via `nearbyCacheKey(...)` instead of an inline template literal. |
| `invalidateNearbyCache` | Now builds the glob as `${nearbyCachePrefix(lat, lon)}:*` instead of `toFixed(4)`-rounded coordinates. |

Matched by `Backend/src/gists/gists.service.spec.ts`.

## Integration changes outside `Backend/src/gists/gists.service.ts`

- **`Backend/src/gists/gists.service.spec.ts`** — added the `nearby cache invalidation` suite, which captures the key `findNearby` writes (via `cacheService.set`) and the pattern `create` invalidates with (via `cacheService.delPattern`) at a coordinate with 7 decimal places, then asserts the pattern uses the raw coordinates and its `*` suffix matches the captured key.

No other files modified; the change is internal to `GistsService` and its spec.

## Acceptance criteria coverage

- [x] A gist posted at a coordinate whose raw lat/lon has more than 4 decimal places invalidates cached `findNearby` results that include that coordinate. (`invalidateNearbyCache` uses raw coordinates via `nearbyCachePrefix`; `gists.service.spec.ts` — "invalidates with the same full-precision coordinates findNearby caches with", using `lat = 9.0579123` / `lon = 7.4951567`)
- [x] The cache key and invalidation pattern derive from the same coordinate representation (canonicalized consistently). (`nearbyCachePrefix` is the single serializer consumed by both `nearbyCacheKey` and `invalidateNearbyCache`)
- [x] A unit test in `gists.service.spec.ts` asserts `cacheService.delPattern` is called with a pattern that matches the key `findNearby` would have written. (`nearby cache invalidation` suite — asserts `pattern === 'gist:nearby:<lat>:<lon>:*'` and `cacheKey.startsWith(pattern.slice(0, -1))`)

## Test plan

- [x] `CI=true npm test -- --runInBand` — 181 passed, 13 skipped (1 new test; skips are the pre-existing Postgres+PostGIS integration suites)
- [x] `npx tsc --noEmit -p tsconfig.json` — 0 errors
- [x] `npx eslint <changed files>` — no new errors versus base; the file has one pre-existing auto-fixable `prettier/prettier` error on the untouched `createBatch` signature (present on `main`), which the repo's `npm run lint` (`eslint --fix`) auto-fixes
- [x] `npm run build` — succeeds
- [ ] Manual: none; the key/pattern relationship is covered by the behavioral unit test.

## Env vars / Notes

No new environment variables or config keys. No persisted data shape changed. `CacheService.delPattern`'s Redis `KEYS`-based scan is left as-is (replacing it with `SCAN` is explicitly out of scope for this issue), as is caching of paginated (cursor) responses.