### PR TITLE
fix(health): make DB/PostGIS probe the sole GET /health handler

### DIFF
--- a/Backend/src/app.controller.ts
+++ b/Backend/src/app.controller.ts
@@ -1,16 +1,8 @@
 import { Controller, Get, Req } from '@nestjs/common';
 import { Request } from 'express';
-import { AppService } from './app.service';
 
 @Controller()
 export class AppController {
-  constructor(private readonly appService: AppService) {}
-
-  @Get('health')
-  health() {
-    return this.appService.health();
-  }
-
   @Get('csrf-token')
   csrfToken(@Req() req: Request) {
     return { csrfToken: (req as any).csrfToken?.() };

--- a/Backend/src/app.module.ts
+++ b/Backend/src/app.module.ts
@@ -10,7 +10,6 @@ import { GistsModule } from './gists/gists.module';
 import { HealthModule } from './health/health.module';
 import { CacheModule } from './cache/cache.module';
 import { AppController } from './app.controller';
-import { AppService } from './app.service';
 
 @Module({
   imports: [
@@ -35,7 +34,6 @@ import { AppService } from './app.service';
   ],
   controllers: [AppController],
   providers: [
-    AppService,
     {
       provide: APP_GUARD,
       useClass: ThrottlerGuard,

--- a/Backend/src/app.service.ts
+++ b/Backend/src/app.service.ts
@@ -1,8 +1,0 @@
-import { Injectable } from '@nestjs/common';
-
-@Injectable()
-export class AppService {
-  health(): { status: string } {
-    return { status: 'ok' };
-  }
-}

--- a/Backend/test/app.e2e-spec.ts
+++ b/Backend/test/app.e2e-spec.ts
@@ -46,4 +46,18 @@ describe('AppModule (e2e)', () => {
       expect(res.body.status).toBe('degraded');
     }
   });
+
+  it('GET /health is served by the DB/PostGIS probe, never the static placeholder', async () => {
+    // Regression guard for #429: AppController used to register a second
+    // GET /health that returned a static `{ status: 'ok' }` body and raced
+    // the real probe for the same route. That handler is gone, so the
+    // response must always carry the `services` envelope the probe emits;
+    // the static placeholder never has one.
+    const res = await request(app.getHttpServer()).get('/health');
+
+    expect([200, 503]).toContain(res.status);
+    expect(res.body).not.toEqual({ status: 'ok' });
+    expect(res.body.services).toHaveProperty('database');
+    expect(res.body.services).toHaveProperty('postgis');
+  });
 });


### PR DESCRIPTION
## Summary

`GET /health` was registered twice: `AppController.health` returned a static `{ status: 'ok' }`, while `HealthController.check` ran the real liveness probes (`SELECT 1` + `postgis_lib_version()`) and returned `200`/`503` with a `services` envelope. Both handlers mapped to the same path, so whichever Express resolved first responded and the other was dead code — a future change to module/import ordering could silently flip `/health` to a static `200`, defeating the Docker `HEALTHCHECK` and Kubernetes liveness probe.

This PR removes the duplicate handler so the DB/PostGIS probe is the only responder.

## Related Issue

Closes #429

## Changes

- **`Backend/src/app.controller.ts`**: remove the duplicate `@Get('health')` handler; `/csrf-token` is unchanged.
- **`Backend/src/app.service.ts`**: delete the now-unused `AppService` (it only existed to serve the static health body).
- **`Backend/src/app.module.ts`**: drop the `AppService` provider and import.
- **`Backend/test/app.e2e-spec.ts`**: add a regression test asserting `GET /health` always returns the probe's `services.database`/`services.postgis` envelope and never the static `{ status: 'ok' }` placeholder.

## How to test

```bash
cd Backend
npm install
npm test            # unit tests (DB integration suite is skipped unless a live Postgres+PostGIS is available)
npm run test:e2e    # e2e; requires Postgres+PostGIS
npm run build
```

- `GET /health` returns `200 { status: 'ok', services: { database: ..., postgis: ... } }` when Postgres/PostGIS respond.
- `GET /health` returns `503 { status: 'degraded', ... }` when either probe fails.
- `GET /csrf-token` keeps working.

## Checklist

- [x] Tests added/updated
- [x] Lint/format ran (`eslint` clean on changed files)
- [x] Build passes (`npm run build`)
- [x] Documentation updated (if applicable) — n/a